### PR TITLE
impl Clone for JoinIter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+* Implement `Clone` for some `JoinIter`. ([#620])
+* Bump `hibitset` to `0.6.3`. ([#620])
+
+[#620]: https://github.com/slide-rs/specs/pull/620
+
 # 0.16.0
 
 * Update `syn`, `quote` and `proc-macro2` to `1.0`. ([#648])
@@ -17,7 +24,7 @@
 
 # 0.15.1
 
-* Benchmark uses `nalgebra` instead of `cgmath`. ([#619]).
+* Benchmark uses `nalgebra` instead of `cgmath`. ([#619])
 * Bumped `shrev` from `1.0` to `1.1`. ([#619]).
 * Update hashbrown to 0.6.0, criterion to 0.3 ([#627], [#632])
 * Remove `mopa` in favour of `std::any::Any` ([#631])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ travis-ci = { repository = "slide-rs/specs" }
 [dependencies]
 crossbeam-queue = "0.2.1"
 hashbrown = "0.7.0"
-hibitset = { version = "0.6.2", default-features = false }
+hibitset = { version = "0.6.3", default-features = false }
 log = "0.4.8"
 shred = { version = "0.10.2", default-features = false }
 shrev = "1.1.1"


### PR DESCRIPTION
Closes #593 

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs

## API changes

implement `Clone` for `JoinIter` where possible.
Updates hibitset version as this requires access to `BitIter::clone` and `BitIterAnd::clone`.
This is not a breaking change
