### PR TITLE
add fn replace to StorageEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# Unreleased
+# 0.16.1
 
 * Implement `Clone` for some `JoinIter`. ([#620])
 * Bump `hibitset` to `0.6.3`. ([#620])
+* Add `fn StorageEntry::replace`. ([#622])
 
 [#620]: https://github.com/slide-rs/specs/pull/620
 

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -254,6 +254,18 @@ where
     T: Component,
     D: DerefMut<Target = MaskedStorage<T>>,
 {
+    /// Inserts a component and returns the old value in case this entry was
+    /// already occupied.
+    pub fn replace(self, component: T) -> Option<T> {
+        match self {
+            StorageEntry::Occupied(mut occupied) => Some(occupied.insert(component)),
+            StorageEntry::Vacant(vacant) => {
+                vacant.insert(component);
+                None
+            }
+        }
+    }
+
     /// Inserts a component if the entity does not have it already.
     pub fn or_insert(self, component: T) -> &'a mut T {
         self.or_insert_with(|| component)

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -771,6 +771,9 @@ mod test {
         let e5 = w.create_entity().build();
         let e6 = w.create_entity().with(Cvec(10)).build();
 
+        let e7 = w.create_entity().build();
+        let e8 = w.create_entity().with(Cvec(10)).build();
+
         let mut s1 = w.write_storage::<Cvec>();
 
         // Basic entry usage.
@@ -833,10 +836,19 @@ mod test {
 
             toggle(e5);
             toggle(e6);
+
+            assert_eq!(s1.get(e5), Some(&Cvec(15)));
+            assert_eq!(s1.get(e6), None);
         }
 
-        assert_eq!(s1.get(e5), Some(&Cvec(15)));
-        assert_eq!(s1.get(e6), None);
+        // Check that `StorageEntry::replace` works as expected
+        {
+            assert_eq!(s1.entry(e7).unwrap().replace(Cvec(1337)), None);
+            assert_eq!(s1.entry(e8).unwrap().replace(Cvec(11)), Some(Cvec(10)));
+            assert_eq!(s1.entry(e7).unwrap().replace(Cvec(9001)), Some(Cvec(1337)));
+            assert_eq!(s1.get(e7), Some(&Cvec(9001)));
+            assert_eq!(s1.get(e8), Some(&Cvec(11)));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds a method to StorageEntry:
```rust
/// Inserts a component and returns the old value in case this entry was
/// already occupied.
pub fn replace(self, component: T) -> Option<T> {
    match self {
        StorageEntry::Occupied(mut occupied) => Some(occupied.insert(component)),
        StorageEntry::Vacant(vacant) => {
            vacant.insert(component);
            None
        }
    }
}
```

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

addition of the method `StorageEntry::replace(self, component: T) -> Option<T>`.
This is not a breaking change
