### PR TITLE
Add clone implementation for Storage

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -336,6 +336,12 @@ where
     }
 }
 
+impl<'a, T, D: Clone> Clone for Storage<'a, T, D> {
+    fn clone(&self) -> Self {
+        Storage::new(self.entities.clone(), self.data.clone())
+    }
+}
+
 // SAFETY: This is safe, since `T::Storage` is `DistinctStorage` and `Join::get`
 // only accesses the storage and nothing else.
 unsafe impl<'a, T: Component, D> DistinctStorage for Storage<'a, T, D> where


### PR DESCRIPTION
## Checklist

* [x] **(not applicable)** I've added tests for all code changes and additions (where applicable)
* [x] **(not necessary)** I've added a demonstration of the new feature to one or more examples
* [x] **(not necessary)** I've updated the book to reflect my changes
* [x] **(trait impl will appear in rustdoc)** Usage of new public items is shown in the API docs

## API changes

This allows users to clone their `ReadStorage` and `WriteStorage` ***fetches*** by adding `Clone` for `Storage<'a, T, D: Clone>`.