### PR TITLE
Use log::warn! instead of println! for is_unconstrained joins.

### DIFF
--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -302,8 +302,8 @@ impl<J: Join> JoinIter<J> {
     /// Create a new join iterator.
     pub fn new(j: J) -> Self {
         if <J as Join>::is_unconstrained() {
-            println!(
-                "WARNING: `Join` possibly iterating through all indices, you might've made a join with all `MaybeJoin`s, which is unbounded in length."
+            log::warn!(
+                "`Join` possibly iterating through all indices, you might've made a join with all `MaybeJoin`s, which is unbounded in length."
             );
         }
 

--- a/src/join/par_join.rs
+++ b/src/join/par_join.rs
@@ -27,8 +27,8 @@ pub unsafe trait ParJoin: Join {
         Self: Sized,
     {
         if <Self as Join>::is_unconstrained() {
-            println!(
-                "WARNING: `ParJoin` possibly iterating through all indices, you might've made a join with all `MaybeJoin`s, which is unbounded in length."
+            log::warn!(
+                "`ParJoin` possibly iterating through all indices, you might've made a join with all `MaybeJoin`s, which is unbounded in length."
             );
         }
 


### PR DESCRIPTION
log is already used in lazy.rs, and the println!s represent their own performance hazard if you really did mean to do an unbounded join.

Additionally, stdio is unavailable or forbidden on some platforms (wasm in the browser, consoles, etc.)

No related issues to mark as fixed.

## ~~Checklist~~

Presumably already covered by existing tests/docs

## API changes

None
