### PR TITLE
Implement `ParJoin` for `MaybeJoin` if the inner type is `ParJoin`

### DIFF
--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -291,6 +291,15 @@ where
     }
 }
 
+// SAFETY: This is safe as long as `T` implements `ParJoin` safely.  `MaybeJoin` relies on `T as
+// Join` for all storage access and safely wraps the inner `Join` API, so it should also be able to
+// implement `ParJoin`.
+#[cfg(feature = "parallel")]
+unsafe impl<T> ParJoin for MaybeJoin<T>
+where
+    T: ParJoin,
+{}
+
 /// `JoinIter` is an `Iterator` over a group of `Storages`.
 #[must_use]
 pub struct JoinIter<J: Join> {


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

I've added a simple test to make sure `ParJoin` actually works with `MaybeJoin`, but I haven't updated any of the examples.

The test is not terribly important as it wasn't really a question whether it would work or not, the real question is whether it's safe.