### PR TITLE
Generic maskedstorage

### DIFF
--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -118,17 +118,18 @@ use crate::{
 /// Note that you can also use `LazyUpdate` , which does insertions on
 /// `World::maintain`. This allows more concurrency and is designed
 /// to be used for entity initialization.
-pub type ReadStorage<'a, T> = Storage<'a, T, Fetch<'a, MaskedStorage<T>>>;
+#[allow(type_alias_bounds)]
+pub type ReadStorage<'a, T: Component> = Storage<'a, T, Fetch<'a, MaskedStorage<T, T::Storage>>>;
 
 impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
 where
     T: Component,
 {
     fn setup(res: &mut World) {
-        res.entry::<MaskedStorage<T>>()
+        res.entry::<MaskedStorage<T, T::Storage>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T>>());
+            .register(&*res.fetch::<MaskedStorage<T, T::Storage>>());
     }
 
     fn fetch(res: &'a World) -> Self {
@@ -138,7 +139,7 @@ where
     fn reads() -> Vec<ResourceId> {
         vec![
             ResourceId::new::<EntitiesRes>(),
-            ResourceId::new::<MaskedStorage<T>>(),
+            ResourceId::new::<MaskedStorage<T, T::Storage>>(),
         ]
     }
 
@@ -209,17 +210,18 @@ where
 ///
 /// There's also an Entry-API similar to the one provided by
 /// `std::collections::HashMap`.
-pub type WriteStorage<'a, T> = Storage<'a, T, FetchMut<'a, MaskedStorage<T>>>;
+#[allow(type_alias_bounds)]
+pub type WriteStorage<'a, T: Component> = Storage<'a, T, FetchMut<'a, MaskedStorage<T, T::Storage>>>;
 
 impl<'a, T> SystemData<'a> for WriteStorage<'a, T>
 where
     T: Component,
 {
     fn setup(res: &mut World) {
-        res.entry::<MaskedStorage<T>>()
+        res.entry::<MaskedStorage<T, T::Storage>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T>>());
+            .register(&*res.fetch::<MaskedStorage<T, T::Storage>>());
     }
 
     fn fetch(res: &'a World) -> Self {
@@ -231,7 +233,7 @@ where
     }
 
     fn writes() -> Vec<ResourceId> {
-        vec![ResourceId::new::<MaskedStorage<T>>()]
+        vec![ResourceId::new::<MaskedStorage<T, T::Storage>>()]
     }
 }
 

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -119,17 +119,17 @@ use crate::{
 /// `World::maintain`. This allows more concurrency and is designed
 /// to be used for entity initialization.
 #[allow(type_alias_bounds)]
-pub type ReadStorage<'a, T: Component> = Storage<'a, T, Fetch<'a, MaskedStorage<T, T::Storage>>>;
+pub type ReadStorage<'a, T: Component> = Storage<'a, T, Fetch<'a, MaskedStorage<T::Storage>>>;
 
 impl<'a, T> SystemData<'a> for ReadStorage<'a, T>
 where
     T: Component,
 {
     fn setup(res: &mut World) {
-        res.entry::<MaskedStorage<T, T::Storage>>()
+        res.entry::<MaskedStorage<T::Storage>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T, T::Storage>>());
+            .register(&*res.fetch::<MaskedStorage<T::Storage>>());
     }
 
     fn fetch(res: &'a World) -> Self {
@@ -139,7 +139,7 @@ where
     fn reads() -> Vec<ResourceId> {
         vec![
             ResourceId::new::<EntitiesRes>(),
-            ResourceId::new::<MaskedStorage<T, T::Storage>>(),
+            ResourceId::new::<MaskedStorage<T::Storage>>(),
         ]
     }
 
@@ -211,17 +211,17 @@ where
 /// There's also an Entry-API similar to the one provided by
 /// `std::collections::HashMap`.
 #[allow(type_alias_bounds)]
-pub type WriteStorage<'a, T: Component> = Storage<'a, T, FetchMut<'a, MaskedStorage<T, T::Storage>>>;
+pub type WriteStorage<'a, T: Component> = Storage<'a, T, FetchMut<'a, MaskedStorage<T::Storage>>>;
 
 impl<'a, T> SystemData<'a> for WriteStorage<'a, T>
 where
     T: Component,
 {
     fn setup(res: &mut World) {
-        res.entry::<MaskedStorage<T, T::Storage>>()
+        res.entry::<MaskedStorage<T::Storage>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T, T::Storage>>());
+            .register(&*res.fetch::<MaskedStorage<T::Storage>>());
     }
 
     fn fetch(res: &'a World) -> Self {
@@ -233,7 +233,7 @@ where
     }
 
     fn writes() -> Vec<ResourceId> {
-        vec![ResourceId::new::<MaskedStorage<T, T::Storage>>()]
+        vec![ResourceId::new::<MaskedStorage<T::Storage>>()]
     }
 }
 

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -261,10 +261,10 @@ mod tests {
 
         let mut d = DispatcherBuilder::new().with(Sys, "sys", &[]).build();
 
-        assert!(!w.has_value::<MaskedStorage<Foo>>());
+        assert!(!w.has_value::<MaskedStorage<<Foo as Component>::Storage>>());
 
         d.setup(&mut w);
 
-        assert!(w.has_value::<MaskedStorage<Foo>>());
+        assert!(w.has_value::<MaskedStorage<<Foo as Component>::Storage>>());
     }
 }

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -10,7 +10,7 @@ use crate::{
 /// that removes the components.
 pub struct Drain<'a, T: Component> {
     /// The masked storage
-    pub data: &'a mut MaskedStorage<T, T::Storage>,
+    pub data: &'a mut MaskedStorage<T::Storage>,
 }
 
 impl<'a, T> Join for Drain<'a, T>
@@ -19,7 +19,7 @@ where
 {
     type Mask = BitSet;
     type Type = T;
-    type Value = &'a mut MaskedStorage<T, T::Storage>;
+    type Value = &'a mut MaskedStorage<T::Storage>;
 
     // SAFETY: No invariants to meet and no unsafe code.
     unsafe fn open(self) -> (Self::Mask, Self::Value) {

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -10,7 +10,7 @@ use crate::{
 /// that removes the components.
 pub struct Drain<'a, T: Component> {
     /// The masked storage
-    pub data: &'a mut MaskedStorage<T>,
+    pub data: &'a mut MaskedStorage<T, T::Storage>,
 }
 
 impl<'a, T> Join for Drain<'a, T>
@@ -19,7 +19,7 @@ where
 {
     type Mask = BitSet;
     type Type = T;
-    type Value = &'a mut MaskedStorage<T>;
+    type Value = &'a mut MaskedStorage<T, T::Storage>;
 
     // SAFETY: No invariants to meet and no unsafe code.
     unsafe fn open(self) -> (Self::Mask, Self::Value) {

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -6,7 +6,7 @@ use crate::join::Join;
 impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Returns an entry to the component associated to the entity.
     ///
@@ -110,7 +110,7 @@ where
     /// for (mut counter, _) in (counters.entries(), &marker).join() {
     ///     let counter = counter.or_insert_with(Default::default);
     ///     counter.increase();
-    ///         
+    ///
     ///     if counter.reached_limit() {
     ///         counter.reset();
     ///         // Do something
@@ -130,7 +130,7 @@ pub struct Entries<'a, 'b: 'a, T: 'a, D: 'a>(&'a mut Storage<'b, T, D>);
 impl<'a, 'b: 'a, T: 'a, D: 'a> Join for Entries<'a, 'b, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T>>,
+    D: Deref<Target = MaskedStorage<T, T::Storage>>,
 {
     type Mask = BitSetAll;
     type Type = StorageEntry<'a, 'b, T, D>;
@@ -175,7 +175,7 @@ pub struct OccupiedEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> OccupiedEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T>>,
+    D: Deref<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Get a reference to the component associated with the entity.
     pub fn get(&self) -> &T {
@@ -188,7 +188,7 @@ where
 impl<'a, 'b, T, D> OccupiedEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Get a mutable reference to the component associated with the entity.
     pub fn get_mut(&mut self) -> &mut T {
@@ -227,7 +227,7 @@ pub struct VacantEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> VacantEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Inserts a value into the storage.
     pub fn insert(self, component: T) -> &'a mut T {
@@ -252,7 +252,7 @@ pub enum StorageEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> StorageEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Inserts a component if the entity does not have it already.
     pub fn or_insert(self, component: T) -> &'a mut T {

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -6,7 +6,7 @@ use crate::join::Join;
 impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Returns an entry to the component associated to the entity.
     ///
@@ -130,7 +130,7 @@ pub struct Entries<'a, 'b: 'a, T: 'a, D: 'a>(&'a mut Storage<'b, T, D>);
 impl<'a, 'b: 'a, T: 'a, D: 'a> Join for Entries<'a, 'b, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T, T::Storage>>,
+    D: Deref<Target = MaskedStorage<T::Storage>>,
 {
     type Mask = BitSetAll;
     type Type = StorageEntry<'a, 'b, T, D>;
@@ -175,7 +175,7 @@ pub struct OccupiedEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> OccupiedEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T, T::Storage>>,
+    D: Deref<Target = MaskedStorage<T::Storage>>,
 {
     /// Get a reference to the component associated with the entity.
     pub fn get(&self) -> &T {
@@ -188,7 +188,7 @@ where
 impl<'a, 'b, T, D> OccupiedEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Get a mutable reference to the component associated with the entity.
     pub fn get_mut(&mut self) -> &mut T {
@@ -227,7 +227,7 @@ pub struct VacantEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> VacantEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Inserts a value into the storage.
     pub fn insert(self, component: T) -> &'a mut T {
@@ -252,7 +252,7 @@ pub enum StorageEntry<'a, 'b: 'a, T: 'a, D: 'a> {
 impl<'a, 'b, T, D> StorageEntry<'a, 'b, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Inserts a component if the entity does not have it already.
     pub fn or_insert(self, component: T) -> &'a mut T {

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -199,7 +199,9 @@ where
     }
 }
 
-impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T> {
+impl<C: Component, T: UnprotectedStorage<Item = C>> UnprotectedStorage for FlaggedStorage<C, T> {
+    type Item = C;
+
     unsafe fn clean<B>(&mut self, has: B)
     where
         B: BitSetLike,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -157,6 +157,11 @@ impl<S: UnprotectedStorage> MaskedStorage<S> {
         self.mask.clear();
     }
 
+    /// Check if the given id refers to a valid element in the storage.
+    pub fn contains(&self, id: Index) -> bool {
+        self.mask.contains(id)
+    }
+
     /// Get an element by a given index.
     pub fn get(&self, id: Index) -> Option<&S::Item> {
         if self.mask.contains(id) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -157,6 +157,26 @@ impl<S: UnprotectedStorage> MaskedStorage<S> {
         self.mask.clear();
     }
 
+    /// Get an element by a given index.
+    pub fn get(&self, id: Index) -> Option<&S::Item> {
+        if self.mask.contains(id) {
+            // SAFETY: We checked the mask (`contains` returned `true`)
+            Some(unsafe { self.inner.get(id) })
+        } else {
+            None
+        }
+    }
+
+    /// Get an element mutably by a given index.
+    pub fn get_mut(&mut self, id: Index) -> Option<&mut S::Item> {
+        if self.mask.contains(id) {
+            // SAFETY: We checked the mask (`contains` returned `true`)
+            Some(unsafe { self.inner.get_mut(id) })
+        } else {
+            None
+        }
+    }
+
     /// Remove an element by a given index.
     pub fn remove(&mut self, id: Index) -> Option<S::Item> {
         if self.mask.remove(id) {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -478,7 +478,9 @@ where
 }
 
 /// Used by the framework to quickly join components.
-pub trait UnprotectedStorage<T>: TryDefault {
+pub trait UnprotectedStorage: TryDefault {
+    /// The item that is stored.
+    type Item;
     /// Clean the storage given a bitset with bits set for valid indices.
     /// Allows us to safely drop the storage.
     ///
@@ -501,7 +503,7 @@ pub trait UnprotectedStorage<T>: TryDefault {
     ///
     /// A mask should keep track of those states, and an `id` being contained
     /// in the tracking mask is sufficient to call this method.
-    unsafe fn get(&self, id: Index) -> &T;
+    unsafe fn get(&self, id: Index) -> &Self::Item;
 
     /// Tries mutating the data associated with an `Index`.
     /// This is unsafe because the external set used
@@ -514,7 +516,7 @@ pub trait UnprotectedStorage<T>: TryDefault {
     ///
     /// A mask should keep track of those states, and an `id` being contained
     /// in the tracking mask is sufficient to call this method.
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T;
+    unsafe fn get_mut(&mut self, id: Index) -> &mut Self::Item;
 
     /// Inserts new data for a given `Index`.
     ///
@@ -525,7 +527,7 @@ pub trait UnprotectedStorage<T>: TryDefault {
     ///
     /// A mask should keep track of those states, and an `id` missing from the
     /// mask is sufficient to call `insert`.
-    unsafe fn insert(&mut self, id: Index, value: T);
+    unsafe fn insert(&mut self, id: Index, value: Self::Item);
 
     /// Removes the data associated with an `Index`.
     ///
@@ -533,7 +535,7 @@ pub trait UnprotectedStorage<T>: TryDefault {
     ///
     /// May only be called if an element with `id` was `insert`ed and not yet
     /// removed / dropped.
-    unsafe fn remove(&mut self, id: Index) -> T;
+    unsafe fn remove(&mut self, id: Index) -> Self::Item;
 
     /// Drops the data associated with an `Index`.
     /// This is simply more efficient than `remove` and can be used if the data

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -161,7 +161,7 @@ where
 impl<'st, T, D> Storage<'st, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T, T::Storage>>,
+    D: Deref<Target = MaskedStorage<T::Storage>>,
 {
     /// Builds an immutable `RestrictedStorage` out of a `Storage`. Allows
     /// deferred unchecked access to the entity's component.
@@ -184,7 +184,7 @@ where
 impl<'st, T, D> Storage<'st, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Builds a mutable `RestrictedStorage` out of a `Storage`. Allows
     /// restricted access to the inner components without allowing

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -161,7 +161,7 @@ where
 impl<'st, T, D> Storage<'st, T, D>
 where
     T: Component,
-    D: Deref<Target = MaskedStorage<T>>,
+    D: Deref<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Builds an immutable `RestrictedStorage` out of a `Storage`. Allows
     /// deferred unchecked access to the entity's component.
@@ -184,7 +184,7 @@ where
 impl<'st, T, D> Storage<'st, T, D>
 where
     T: Component,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Builds a mutable `RestrictedStorage` out of a `Storage`. Allows
     /// restricted access to the inner components without allowing

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -29,7 +29,9 @@ pub trait SliceAccess<T> {
 #[derivative(Default(bound = ""))]
 pub struct BTreeStorage<T>(BTreeMap<Index, T>);
 
-impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
+impl<T> UnprotectedStorage for BTreeStorage<T> {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -63,7 +65,9 @@ unsafe impl<T> DistinctStorage for BTreeStorage<T> {}
 #[derivative(Default(bound = ""))]
 pub struct HashMapStorage<T>(HashMap<Index, T>);
 
-impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
+impl<T> UnprotectedStorage for HashMapStorage<T> {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -132,7 +136,9 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
     }
 }
 
-impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
+impl<T> UnprotectedStorage for DenseVecStorage<T> {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -177,10 +183,12 @@ unsafe impl<T> DistinctStorage for DenseVecStorage<T> {}
 /// doesn't contain any data and instead works as a simple flag.
 pub struct NullStorage<T>(T);
 
-impl<T> UnprotectedStorage<T> for NullStorage<T>
+impl<T> UnprotectedStorage for NullStorage<T>
 where
     T: Default,
 {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -243,7 +251,9 @@ impl<T> SliceAccess<T> for VecStorage<T> {
     }
 }
 
-impl<T> UnprotectedStorage<T> for VecStorage<T> {
+impl<T> UnprotectedStorage for VecStorage<T> {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, has: B)
         where
             B: BitSetLike,
@@ -298,7 +308,9 @@ unsafe impl<T> DistinctStorage for VecStorage<T> {}
 #[derivative(Default(bound = ""))]
 pub struct DefaultVecStorage<T>(Vec<T>);
 
-impl<T> UnprotectedStorage<T> for DefaultVecStorage<T> where T: Default {
+impl<T> UnprotectedStorage for DefaultVecStorage<T> where T: Default {
+    type Item = T;
+
     unsafe fn clean<B>(&mut self, _has: B)
         where
             B: BitSetLike,

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -46,7 +46,7 @@ impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
     T::Storage: Tracked,
-    D: Deref<Target = MaskedStorage<T, T::Storage>>,
+    D: Deref<Target = MaskedStorage<T::Storage>>,
 {
     /// Returns the event channel tracking modified components.
     pub fn channel(&self) -> &EventChannel<ComponentEvent> {
@@ -64,7 +64,7 @@ impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
     T::Storage: Tracked,
-    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
+    D: DerefMut<Target = MaskedStorage<T::Storage>>,
 {
     /// Returns the event channel for insertions/removals/modifications of this
     /// storage's components.

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -46,7 +46,7 @@ impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
     T::Storage: Tracked,
-    D: Deref<Target = MaskedStorage<T>>,
+    D: Deref<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Returns the event channel tracking modified components.
     pub fn channel(&self) -> &EventChannel<ComponentEvent> {
@@ -64,7 +64,7 @@ impl<'e, T, D> Storage<'e, T, D>
 where
     T: Component,
     T::Storage: Tracked,
-    D: DerefMut<Target = MaskedStorage<T>>,
+    D: DerefMut<Target = MaskedStorage<T, T::Storage>>,
 {
     /// Returns the event channel for insertions/removals/modifications of this
     /// storage's components.

--- a/src/world/comp.rs
+++ b/src/world/comp.rs
@@ -62,5 +62,5 @@ use crate::storage::UnprotectedStorage;
 /// ```
 pub trait Component: Any + Sized {
     /// Associated storage type for this component.
-    type Storage: UnprotectedStorage<Self> + Any + Send + Sync;
+    type Storage: UnprotectedStorage<Item = Self> + Any + Send + Sync;
 }

--- a/src/world/world_ext.rs
+++ b/src/world/world_ext.rs
@@ -314,11 +314,11 @@ impl WorldExt for World {
         T: Component,
     {
         self.entry()
-            .or_insert_with(move || MaskedStorage::<T, T::Storage>::new(storage()));
+            .or_insert_with(move || MaskedStorage::<T::Storage>::new(storage()));
         self.entry::<MetaTable<dyn AnyStorage>>()
             .or_insert_with(Default::default);
         self.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*self.fetch::<MaskedStorage<T, T::Storage>>());
+            .register(&*self.fetch::<MaskedStorage<T::Storage>>());
     }
 
     fn add_resource<T: Resource>(&mut self, res: T) {

--- a/src/world/world_ext.rs
+++ b/src/world/world_ext.rs
@@ -314,11 +314,11 @@ impl WorldExt for World {
         T: Component,
     {
         self.entry()
-            .or_insert_with(move || MaskedStorage::<T>::new(storage()));
+            .or_insert_with(move || MaskedStorage::<T, T::Storage>::new(storage()));
         self.entry::<MetaTable<dyn AnyStorage>>()
             .or_insert_with(Default::default);
         self.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*self.fetch::<MaskedStorage<T>>());
+            .register(&*self.fetch::<MaskedStorage<T, T::Storage>>());
     }
 
     fn add_resource<T: Resource>(&mut self, res: T) {


### PR DESCRIPTION
Fixes #664 

## API changes

This changes three things:
* `UnprotectedStorage` has its item type as an associated type rather than as a generic type parameter.
* The type parameter of `MaskedStorage` is now the inner storage, rather than the item type.
This allows any item to be stored in a `MaskedStorage`, rather than only `Component`s.
* `MaskedStorage` now has `contains`, `get` and `get_mut` methods.