### PR TITLE
Change homepage to specs.amethyst.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ Specs is an Entity-Component-System library written in Rust.
 """
 documentation = "https://docs.rs/specs/"
 repository = "https://github.com/slide-rs/specs"
-homepage = "https://slide-rs.github.io/"
+homepage = "https://specs.amethyst.rs"
 readme = "README.md"
 keywords = ["gamedev", "ecs", "entity", "component"]
 categories = ["concurrency", "game-engines"]


### PR DESCRIPTION
Closes #672 

Note : Homepage could be [https://specs.netlify.com](https://specs.netlify.com) instead