### PR TITLE
Add derive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 * Deprecate `error::NoError` in favor of `std::convert::Infallible` ([#688])
 * Use `#[non_exhaustive]` for `error::Error`. Note this bumps the minimum supported rust version to 1.40 ([#688]).
+* Add the `derive` feature that enables all derive-related smaller features
+  (`specs-derive` and `shred-derive` currently). ([#687])
 
 [#688]: https://github.com/amethyst/specs/pull/688
+[#687]: https://github.com/amethyst/specs/pull/687
 
 # 0.16.1 (2020-02-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 * Add the `derive` feature that enables all derive-related smaller features
   (`specs-derive` and `shred-derive` currently). ([#687])
 
-[#688]: https://github.com/amethyst/specs/pull/688
 [#687]: https://github.com/amethyst/specs/pull/687
+[#688]: https://github.com/amethyst/specs/pull/688
 
 # 0.16.1 (2020-02-18)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ uuid_entity = ["uuid", "serde"]
 stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
 storage-event-control = []
+derive = ["shred-derive", "specs-derive"]
 
 shred-derive = ["shred/shred-derive"]
 

--- a/docs/tutorials/src/02_hello_world.md
+++ b/docs/tutorials/src/02_hello_world.md
@@ -19,7 +19,7 @@ Add the following line to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-specs = "0.15.0"
+specs = "0.16.1"
 ```
 
 ## Components

--- a/docs/tutorials/src/02_hello_world.md
+++ b/docs/tutorials/src/02_hello_world.md
@@ -54,11 +54,11 @@ These will be our two component types. Optionally, the `specs-derive` crate
 provides a convenient custom `#[derive]` you can use to define component types
 more succinctly.
 
-But first, you will need to enable the `specs-derive` feature:
+But first, you will need to enable the `derive` feature:
 
 ```toml
 [dependencies]
-specs = { version = "0.15.0", features = ["specs-derive"] }
+specs = { version = "0.15.0", features = ["derive"] }
 ```
 
 Now you can do this:

--- a/scripts/build-netlify.sh
+++ b/scripts/build-netlify.sh
@@ -38,7 +38,7 @@ build_book reference
 build_book tutorials
 
 # Build API docs
-FEATURES="parallel serde shred-derive specs-derive uuid_entity"
+FEATURES="parallel serde derive uuid_entity"
 
 echo "Building Rust API docs..."
 cd "${WORKING_DIR}"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! }
 //! ```
 //!
-//! Or alternatively, if you enable the or `derive` feature, you can use a
+//! Or alternatively, if you enable the `"derive"` feature, you can use a
 //! custom `#[derive]` macro:
 //!
 //! ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! }
 //! ```
 //!
-//! Or alternatively, if you enable the `specs-derive` feature, you can use a
+//! Or alternatively, if you enable the or `derive` feature, you can use a
 //! custom `#[derive]` macro:
 //!
 //! ```rust


### PR DESCRIPTION
* There are currently two distinct *-derive features and it is
  uncomfortable to hunt for them.
* They exist mostly due to technical reasons, as they bring two
  different crates. The price of the other if one is already present is
  relatively low (the cost is by depending on syntax and quote and they
  share them).
* This is in the convention of having the `derive` feature flag as serde
  and other packages have.
* The original two are still preserved, so users still can enable only
  one of them.

Closes #684.

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable) (not applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
  Should I update the examples to use this feature, or leave them be with the current `specs-derive`?
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

I'm not sure this completely applies. I've updated the note in docs about features, but otherwise left the `specs-derive` as the main suggestion how to use it by users and expect this will be more like for people who go more by guess than by documentation. But if you prefer, I can update all the examples, etc, to use this new feature flag instead.

## API changes

<!-- Please make it clear if your change is breaking. -->
