### PR TITLE
Cleanup error types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 
 rust:
 - nightly
-- 1.38.0
+- 1.40.0
 - stable
 
 cache:
@@ -22,7 +22,7 @@ script:
     cargo build --all-features --verbose;
     cargo test --all-features --verbose --no-run;
     cargo bench --verbose --no-run --all-features;
-  elif [ "$TRAVIS_RUST_VERSION" == "1.38.0" ]; then
+  elif [ "$TRAVIS_RUST_VERSION" == "1.40.0" ]; then
     cargo check --tests --no-default-features;
     cargo check --tests --no-default-features --features "parallel";
     cargo check --tests --no-default-features --features "serde";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Deprecate `error::NoError` in favor of `std::convert::Infallible` ([#688])
+* Use `#[non_exhaustive]` for `error::Error`. Note this bumps the minimum supported rust version to 1.40 ([#688]).
+
 # 0.16.1 (2020-02-18)
 
 * `JoinIter` now implements `Clone` when inner types are `Clone` -- usually for immutable `join()`s. ([#620])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Deprecate `error::NoError` in favor of `std::convert::Infallible` ([#688])
 * Use `#[non_exhaustive]` for `error::Error`. Note this bumps the minimum supported rust version to 1.40 ([#688]).
 
+[#688]: https://github.com/amethyst/specs/pull/688
+
 # 0.16.1 (2020-02-18)
 
 * `JoinIter` now implements `Clone` when inner types are `Clone` -- usually for immutable `join()`s. ([#620])

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Unlike most other ECS libraries out there, it provides
       other and you can use barriers to force several stages in system execution
 * high performance for real-world applications
 
-Minimum Rust version: 1.38
+Minimum Rust version: 1.40
 
 ## [Link to the book][book]
 

--- a/docs/tutorials/src/13_saveload.md
+++ b/docs/tutorials/src/13_saveload.md
@@ -136,7 +136,7 @@ Here is an example showing how to serialize:
 
 ```rust,ignore
 specs::saveload::SerializeComponents
-    ::<NoError, SimpleMarker<A>>
+    ::<Infallible, SimpleMarker<A>>
     ::serialize(
         &(position_storage, mass_storage),      // tuple of ReadStorage<'a, _>
         &entities,                              // Entities<'a>
@@ -149,7 +149,7 @@ and now, how to deserialize:
 
 ```rust,ignore
 specs::saveload::DeserializeComponents
-    ::<NoError, SimpleMarker<A>>
+    ::<Infallible, SimpleMarker<A>>
     ::deserialize(
         &mut (position_storage, mass_storage),  // tuple of WriteStorage<'a, _>
         &entities,                              // Entities<'a>
@@ -184,7 +184,7 @@ Each `Component` that you will read from and write to must implement
 that are `Clone + serde::Serialize + serde::DeserializeOwned`, however you may
 need to implement it (or derive it using [`specs-derive`]). In which case, you
 may introduce more bounds to the first generic parameter and will need to
-replace `NoError` with a custom type, this custom type must implement
+replace `Infallible` with a custom type, this custom type must implement
 `From<<TheComponent as ConvertSaveload>::Error>` for all `Component`s,
 basically.
 

--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -3,10 +3,7 @@ extern crate ron;
 extern crate serde;
 extern crate specs;
 
-use std::{
-    convert::Infallible,
-    fmt,
-};
+use std::{convert::Infallible, fmt};
 
 use specs::{
     prelude::*,
@@ -69,9 +66,9 @@ impl Component for Mass {
 // It is necessary to supply the `(De)SerializeComponents`-trait with an error
 // type that implements the `Display`-trait. In this case we want to be able to
 // return different errors, and we are going to use a `.ron`-file to store our
-// data. Therefore we use a custom enum, which can display both the `Infallible`and
-// `ron::ser::Error` type. This enum could be extended to incorporate for
-// example `std::io::Error` and more.
+// data. Therefore we use a custom enum, which can display both the
+// `Infallible`and `ron::ser::Error` type. This enum could be extended to
+// incorporate for example `std::io::Error` and more.
 #[derive(Debug)]
 enum Combined {
     Ron(ron::ser::Error),
@@ -161,8 +158,8 @@ fn main() {
             // For serialization we use the
             // [`SerializeComponents`](struct.SerializeComponents.html)-trait's `serialize`
             // function. It takes two generic parameters:
-            // * An unbound type -> `Infallible` (However, the serialize function expects it to
-            //   be bound by the `Display`-trait)
+            // * An unbound type -> `Infallible` (However, the serialize function expects it
+            //   to be bound by the `Display`-trait)
             // * A type implementing the `Marker`-trait ->
             //   [SimpleMarker](struct.SimpleMarker.html) (a convenient, predefined marker)
             //

--- a/examples/saveload.rs
+++ b/examples/saveload.rs
@@ -3,10 +3,12 @@ extern crate ron;
 extern crate serde;
 extern crate specs;
 
-use std::fmt;
+use std::{
+    convert::Infallible,
+    fmt,
+};
 
 use specs::{
-    error::NoError,
     prelude::*,
     saveload::{
         DeserializeComponents, MarkedBuilder, SerializeComponents, SimpleMarker,
@@ -67,7 +69,7 @@ impl Component for Mass {
 // It is necessary to supply the `(De)SerializeComponents`-trait with an error
 // type that implements the `Display`-trait. In this case we want to be able to
 // return different errors, and we are going to use a `.ron`-file to store our
-// data. Therefore we use a custom enum, which can display both the `NoError`and
+// data. Therefore we use a custom enum, which can display both the `Infallible`and
 // `ron::ser::Error` type. This enum could be extended to incorporate for
 // example `std::io::Error` and more.
 #[derive(Debug)]
@@ -94,8 +96,8 @@ impl From<ron::ser::Error> for Combined {
 }
 
 // This cannot be called.
-impl From<NoError> for Combined {
-    fn from(e: NoError) -> Self {
+impl From<Infallible> for Combined {
+    fn from(e: Infallible) -> Self {
         match e {}
     }
 }
@@ -159,7 +161,7 @@ fn main() {
             // For serialization we use the
             // [`SerializeComponents`](struct.SerializeComponents.html)-trait's `serialize`
             // function. It takes two generic parameters:
-            // * An unbound type -> `NoError` (However, the serialize function expects it to
+            // * An unbound type -> `Infallible` (However, the serialize function expects it to
             //   be bound by the `Display`-trait)
             // * A type implementing the `Marker`-trait ->
             //   [SimpleMarker](struct.SimpleMarker.html) (a convenient, predefined marker)
@@ -172,7 +174,7 @@ fn main() {
             //
             // Lastly, we provide a mutable reference to the serializer of choice, which has
             // to have the `serde::ser::Serializer`-trait implemented.
-            SerializeComponents::<NoError, SimpleMarker<NetworkSync>>::serialize(
+            SerializeComponents::<Infallible, SimpleMarker<NetworkSync>>::serialize(
                 &(&pos, &mass),
                 &ents,
                 &markers,

--- a/specs-derive/src/impl_saveload.rs
+++ b/specs-derive/src/impl_saveload.rs
@@ -28,7 +28,7 @@ pub fn impl_saveload(ast: &mut DeriveInput) -> TokenStream {
     add_where_clauses(
         &mut ast.generics.where_clause,
         &ast.generics.params,
-        |ty| parse_quote!(#ty: ConvertSaveload<MA, Error = NoError> + ConvertSaveload<MA, Error = NoError>),
+        |ty| parse_quote!(#ty: ConvertSaveload<MA, Error = std::convert::Infallible> + ConvertSaveload<MA, Error = std::convert::Infallible>),
     );
     add_where_clauses(
         &mut ast.generics.where_clause,
@@ -77,7 +77,7 @@ pub fn impl_saveload(ast: &mut DeriveInput) -> TokenStream {
 
         impl #impl_generics ConvertSaveload<MA> for #name #ty_generics #where_clause {
             type Data = #saveload_name #saveload_ty_generics;
-            type Error = NoError;
+            type Error = std::convert::Infallible;
 
             fn convert_into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
             where

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -77,13 +77,12 @@ fn impl_component(ast: &DeriveInput) -> proc_macro2::TokenStream {
 
 /// Custom derive macro for the `ConvertSaveload` trait.
 ///
-/// Requires `Entity`, `ConvertSaveload`, `Marker` and `NoError` to be in a
-/// scope.
+/// Requires `Entity`, `ConvertSaveload`, `Marker` to be in a scope
 ///
 /// ## Example
 ///
 /// ```rust,ignore
-/// use specs::{Entity, saveload::{ConvertSaveload, Marker}, error::NoError};
+/// use specs::{Entity, saveload::{ConvertSaveload, Marker}};
 ///
 /// #[derive(ConvertSaveload)]
 /// struct Target(Entity);

--- a/src/error.rs
+++ b/src/error.rs
@@ -105,7 +105,7 @@ impl Display for WrongGeneration {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(
             f,
-            "Tried to {} entity {:?}, but the generation is not valid anymore; it should be {:?}",
+            "Tried to {} entity {:?}, but the generation is no longer valid; it should be {:?}",
             self.action, self.entity, self.actual_gen
         )
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -112,3 +112,7 @@ impl Display for WrongGeneration {
 }
 
 impl StdError for WrongGeneration {}
+
+/// Reexport of `Infallible` for a smoother transition.
+#[deprecated = "Use std::convert::Infallible instead"]
+pub type NoError = Infallible;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@
 //! Each error in this module has an `Into<Error>` implementation.
 
 use std::{
+    convert::Infallible,
     error::Error as StdError,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
@@ -42,28 +43,18 @@ impl Display for BoxedErr {
     }
 }
 
-impl StdError for BoxedErr {
-    fn description(&self) -> &str {
-        self.as_ref().description()
-    }
-}
+impl StdError for BoxedErr {}
 
 /// The Specs error type.
 /// This is an enum which is able to represent
 /// all error types of this library.
-///
-/// Please note that you should not use `__NonExhaustive`,
-/// which is a variant specifically added for extensibility
-/// without breakage.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// A custom, boxed error.
     Custom(BoxedErr),
     /// Wrong generation error.
     WrongGeneration(WrongGeneration),
-
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 impl Display for Error {
@@ -71,14 +62,12 @@ impl Display for Error {
         match *self {
             Error::Custom(ref e) => write!(f, "Custom: {}", e),
             Error::WrongGeneration(ref e) => write!(f, "Wrong generation: {}", e),
-
-            Error::__NonExhaustive => unimplemented!(),
         }
     }
 }
 
-impl From<NoError> for Error {
-    fn from(e: NoError) -> Self {
+impl From<Infallible> for Error {
+    fn from(e: Infallible) -> Self {
         match e {}
     }
 }
@@ -90,16 +79,10 @@ impl From<WrongGeneration> for Error {
 }
 
 impl StdError for Error {
-    fn description(&self) -> &str {
-        "A Specs error"
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         let e = match *self {
             Error::Custom(ref e) => e.as_ref(),
             Error::WrongGeneration(ref e) => e,
-
-            Error::__NonExhaustive => unimplemented!(),
         };
 
         Some(e)
@@ -122,33 +105,10 @@ impl Display for WrongGeneration {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         write!(
             f,
-            "Tried to {} entity {:?}, but the generation is wrong; it should be {:?}",
+            "Tried to {} entity {:?}, but the generation is not valid anymore; it should be {:?}",
             self.action, self.entity, self.actual_gen
         )
     }
 }
 
-impl StdError for WrongGeneration {
-    fn description(&self) -> &str {
-        "Used an entity with a generation that is not valid anymore \
-         (e.g. because the entity has been deleted)"
-    }
-}
-
-/// An error type which cannot be instantiated.
-/// Used as a placeholder for associated error types if
-/// something cannot fail.
-#[derive(Debug, PartialEq, Eq)]
-pub enum NoError {}
-
-impl Display for NoError {
-    fn fmt(&self, _: &mut Formatter) -> FmtResult {
-        match *self {}
-    }
-}
-
-impl StdError for NoError {
-    fn description(&self) -> &str {
-        match *self {}
-    }
-}
+impl StdError for WrongGeneration {}

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -83,12 +83,12 @@ pub struct EntityData<M, D> {
 /// ```rust
 /// # extern crate specs;
 /// # #[macro_use] extern crate serde;
-/// use std::convert::Infallible;
 /// use serde::{Deserialize, Serialize};
 /// use specs::{
 ///     prelude::*,
 ///     saveload::{ConvertSaveload, Marker},
 /// };
+/// use std::convert::Infallible;
 ///
 /// struct Target(Entity);
 ///

--- a/src/saveload/mod.rs
+++ b/src/saveload/mod.rs
@@ -24,9 +24,11 @@
 //! see the docs for the `Marker` trait.
 //!
 
+use std::convert::Infallible;
+
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::{error::NoError, world::Entity};
+use crate::world::Entity;
 
 mod de;
 mod marker;
@@ -81,9 +83,9 @@ pub struct EntityData<M, D> {
 /// ```rust
 /// # extern crate specs;
 /// # #[macro_use] extern crate serde;
+/// use std::convert::Infallible;
 /// use serde::{Deserialize, Serialize};
 /// use specs::{
-///     error::NoError,
 ///     prelude::*,
 ///     saveload::{ConvertSaveload, Marker},
 /// };
@@ -106,7 +108,7 @@ pub struct EntityData<M, D> {
 ///     for<'de> M: Deserialize<'de>,
 /// {
 ///     type Data = TargetData<M>;
-///     type Error = NoError;
+///     type Error = Infallible;
 ///
 ///     fn convert_into<F>(&self, mut ids: F) -> Result<Self::Data, Self::Error>
 ///     where
@@ -150,7 +152,7 @@ where
     C: Clone + Serialize + DeserializeOwned,
 {
     type Data = Self;
-    type Error = NoError;
+    type Error = Infallible;
 
     fn convert_into<F>(&self, _: F) -> Result<Self::Data, Self::Error>
     where
@@ -172,7 +174,7 @@ where
     M: Serialize + DeserializeOwned,
 {
     type Data = M;
-    type Error = NoError;
+    type Error = Infallible;
 
     fn convert_into<F>(&self, mut func: F) -> Result<Self::Data, Self::Error>
     where

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -1,10 +1,13 @@
 extern crate ron;
 
-use std::hash::Hash;
+use std::{
+    hash::Hash,
+    convert::Infallible,
+}
 
 use super::*;
 use crate::{
-    error::{Error, NoError},
+    error::Error,
     prelude::*,
 };
 
@@ -75,7 +78,7 @@ mod marker_test {
                 ReadStorage<M>,
                 Read<M::Allocator>,
             )| {
-                SerializeComponents::<NoError, M>::serialize(
+                SerializeComponents::<Infallible, M>::serialize(
                     &(&comp_a, &comp_b),
                     &ents,
                     &markers,

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -1,15 +1,9 @@
 extern crate ron;
 
-use std::{
-    hash::Hash,
-    convert::Infallible,
-};
+use std::{convert::Infallible, hash::Hash};
 
 use super::*;
-use crate::{
-    error::Error,
-    prelude::*,
-};
+use crate::{error::Error, prelude::*};
 
 mod marker_test {
     use super::*;

--- a/src/saveload/tests.rs
+++ b/src/saveload/tests.rs
@@ -3,7 +3,7 @@ extern crate ron;
 use std::{
     hash::Hash,
     convert::Infallible,
-}
+};
 
 use super::*;
 use crate::{

--- a/tests/saveload.rs
+++ b/tests/saveload.rs
@@ -14,7 +14,6 @@ mod tests {
     #[cfg(feature = "uuid_entity")]
     use spocs::saveload::UuidMarker;
     use spocs::{
-        error::NoError,
         saveload::{ConvertSaveload, Marker, SimpleMarker},
         Builder, Entity, World, WorldExt,
     };


### PR DESCRIPTION
## Checklist

* *n/a* I've added tests for all code changes and additions (where applicable)
* *n/a* I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* *n/a* Usage of new public items is shown in the API docs

## API changes

- Use `#[non_exhaustive]` for `error::Error` instead of `__NonExhaustive` trick. **This is a breaking change, and requires a minimal Rust version of 1.40** (previously 1.38). This notably enables to add new error types without it being a breaking change.
- Change `std::error::Error` implementation of different error types, to use "state of the art" functions instead of deprecated ones.
- Deprecated `NoError` and use `std::convert::Infallible`, and re-export the latter as `NoError` for a smoother transition (maybe we should remove completly). This will also allow a smoother transition to never type when it is stabilized.
