### PR TITLE
keep version consistent, correct feature flag

### DIFF
--- a/docs/tutorials/src/02_hello_world.md
+++ b/docs/tutorials/src/02_hello_world.md
@@ -58,7 +58,7 @@ But first, you will need to enable the `derive` feature:
 
 ```toml
 [dependencies]
-specs = { version = "0.15.0", features = ["derive"] }
+specs = { version = "0.16.1", features = ["specs-derive"] }
 ```
 
 Now you can do this:


### PR DESCRIPTION
Could not compile with `features = ["derive"]`. Needed it to be `features = ["specs-derive"]`.

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

