### PR TITLE
Fix typo substituting Position for Velocity

### DIFF
--- a/docs/tutorials/src/07_setup.md
+++ b/docs/tutorials/src/07_setup.md
@@ -28,11 +28,12 @@ Let's say you began by registering Components and Resources first:
 ```rust,ignore
 use specs::prelude::*;
 
+#[derive(Default)]
 struct Gravity;
 
 struct Velocity;
 
-impl Component for Position {
+impl Component for Velocity {
     type Storage = VecStorage<Self>;
 }
 
@@ -41,7 +42,7 @@ struct SimulationSystem;
 impl<'a> System<'a> for SimulationSystem {
     type SystemData = (Read<'a, Gravity>, WriteStorage<'a, Velocity>);
 
-    fn run(_, _) {}
+    fn run(&mut self, _: Self::SystemData) {}
 }
 
 fn main() {


### PR DESCRIPTION
I believe the example intended to be `impl Component for Velocity` rather than `...for Position` as no `Position` struct was present in this example. I also added `#[derive(Default)]` for the `Gravity` struct as it was needed to have an example that would compile. I also gave the `run()` function a valid signature that would allow the example to compile.

