### PR TITLE
Fix documentation on UnprotectedStorage::drop

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -553,8 +553,9 @@ pub trait UnprotectedStorage<T>: TryDefault {
     unsafe fn remove(&mut self, id: Index) -> T;
 
     /// Drops the data associated with an `Index`.
-    /// This is simply more efficient than `remove` and can be used if the data
+    /// This could be used when a more efficient implementation for it exists than `remove` when the data
     /// is no longer needed.
+    /// Defaults to simply calling `remove`.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Fix misleading documentation on `UnprotectedStorage` trait's `drop` method which suggests it has a different implementation than `remove`, while by default it's calling `remove` internally.
