### PR TITLE
Specs tutorial typo: specs-derive features

### DIFF
--- a/docs/tutorials/src/02_hello_world.md
+++ b/docs/tutorials/src/02_hello_world.md
@@ -54,11 +54,11 @@ These will be our two component types. Optionally, the `specs-derive` crate
 provides a convenient custom `#[derive]` you can use to define component types
 more succinctly.
 
-But first, you will need to enable the `derive` feature:
+But first, you will need to enable the `specs-derive` feature:
 
 ```toml
 [dependencies]
-specs = { version = "0.15.0", features = ["derive"] }
+specs = { version = "0.16.1", features = ["specs-derive"] }
 ```
 
 Now you can do this:


### PR DESCRIPTION
A simple typo in `Cargo.toml` for derive feature. If you try to use this:
```
specs = { version = "0.16.1", features = ["derive"] }
```

It will not work, and you get an error:
```
the package `core` depends on `specs`, with features: `derive` but `specs` does not have these features.
```

