### PR TITLE
Add count to serialize.

### DIFF
--- a/src/saveload/ser.rs
+++ b/src/saveload/ser.rs
@@ -44,7 +44,8 @@ where
         E: Display,
         S: Serializer,
     {
-        let mut serseq = serializer.serialize_seq(None)?;
+        let count = (entities, markers).join().count();
+        let mut serseq = serializer.serialize_seq(Some(count))?;
         let ids = |entity| -> Option<M> { markers.get(entity).cloned() };
         for (entity, marker) in (entities, markers).join() {
             serseq.serialize_element(&EntityData::<M, Self::Data> {


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs

## API changes

This change modifies the behavior of serialize to calculate the count of items before handing off to the serde serializer. The majority of formats that serde supports require a known count to prefix the data with. (i.e. bincode, msgpack). Most of these will fail serialization immediatly when trying to use them with component serialization.

There is additional overhead from calculating the number of items but the cost appears to be trivial in comparison to the time spent on serialization.

I did not modify serialize_recusive as it would require a much more expensive double-traversal of the data structures inspecting for contained entities.
