### PR TITLE
Expose paired storage.

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -7,7 +7,7 @@ pub use self::{
     generic::{GenericReadStorage, GenericWriteStorage},
     restrict::{
         ImmutableParallelRestriction, MutableParallelRestriction, RestrictedStorage,
-        SequentialRestriction,
+        SequentialRestriction, PairedStorage
     },
     storages::{
         BTreeStorage, DefaultVecStorage, DenseVecStorage, HashMapStorage, NullStorage, VecStorage,


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [x] Usage of new public items is shown in the API docs

## API changes

This change makes paired storage public to complement the already public restricted storage. The type is not accessible due to the restrict module being private. This means if you want to do anything with paired storage other than treat it as an anonymous type you can't. Given that it does not implement any public traits for storage access, you can't pass it to any other code without wrapping it in another generic type (i.e. putting it in a closure.)

The use case is passing the structure to another function or beyond the original scope it's contained within.
