### PR TITLE
Allow reentrant laziness

### DIFF
--- a/src/world/tests.rs
+++ b/src/world/tests.rs
@@ -85,11 +85,9 @@ fn super_lazy_execution() {
             if let Err(err) = world.write_storage::<Pos>().insert(e, Pos) {
                 panic!("Unable to lazily insert component! {:?}", err);
             }
-        })
+        });
+        assert!(world.read_storage::<Pos>().get(e).is_none());
     });
-
-    world.maintain();
-    assert!(world.read_storage::<Pos>().get(e).is_none());
     world.maintain();
     assert!(world.read_storage::<Pos>().get(e).is_some());
 }

--- a/src/world/tests.rs
+++ b/src/world/tests.rs
@@ -72,6 +72,29 @@ fn lazy_removal() {
 }
 
 #[test]
+fn super_lazy_execution() {
+    let mut world = World::new();
+    world.register::<Pos>();
+
+    let e = {
+        let entity_res = world.read_resource::<EntitiesRes>();
+        entity_res.create()
+    };
+    world.read_resource::<LazyUpdate>().exec(move |world| {
+        world.read_resource::<LazyUpdate>().exec(move |world| {
+            if let Err(err) = world.write_storage::<Pos>().insert(e, Pos) {
+                panic!("Unable to lazily insert component! {:?}", err);
+            }
+        })
+    });
+
+    world.maintain();
+    assert!(world.read_storage::<Pos>().get(e).is_none());
+    world.maintain();
+    assert!(world.read_storage::<Pos>().get(e).is_some());
+}
+
+#[test]
 fn lazy_execution() {
     let mut world = World::new();
     world.register::<Pos>();

--- a/src/world/world_ext.rs
+++ b/src/world/world_ext.rs
@@ -401,10 +401,8 @@ impl WorldExt for World {
             self.delete_components(&deleted);
         }
 
-        // we need to swap the queue out to be able to reborrow self mutable here
-        let mut lazy = self.write_resource::<LazyUpdate>().take();
-        lazy.maintain(&mut *self);
-        self.write_resource::<LazyUpdate>().restore(lazy);
+        let lazy = self.write_resource::<LazyUpdate>().clone();
+        lazy.maintain(self);
     }
 
     fn delete_components(&mut self, delete: &[Entity]) {


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

None
<!-- Please make it clear if your change is breaking. -->

## Description
Before this change if one tried to do `World::system_data<Read<LazyUpdate>>()` within `LazyUpdate::exec` on would get the following error:
```
thread 'main' panicked at 'Already borrowed mutably: InvalidBorrow', /home/delma/.cargo/registry/src/github.com-1ecc6299db9ec823/shred-0.7.2/src/cell.rs:103:9
stack backtrace:                                                                                                                                              
   0: backtrace::backtrace::libunwind::trace                                                             
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized                                                         
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66 
   2: std::sys_common::backtrace::_print_fmt                                                             
             at src/libstd/sys_common/backtrace.rs:78                                                    
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt                  
             at src/libstd/sys_common/backtrace.rs:59                                                    
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1069
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1504
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:511
  11: rust_begin_unwind
             at src/libstd/panicking.rs:419
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:111
  13: core::option::expect_none_failed
             at src/libcore/option.rs:1268
  14: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
  15: specs::world::World::maintain
```
This problem arised in our project when I refactored code such that piece of code so that previously wasn't used inside `LazyUpdate::exec` was now used there. The piece of code is also used outside of `LazyUpdate` so just removing `LazyUpdate` usage in it is non-trivial. 

This PR changes the behavior to allow reentrant `LazyUpdate` usage. After the change reentrant `LazyUpdate::exec`:s will be applied in the order they are created on the same call of `World::maintain`.  Another option was to execute them on the next call to maintain. This option wasn't chosen to make applying lazy updates as soon as possible as `LazyUpdate` is not meant for delaying, but for giving more flexibility.

I think allowing this kind of reentrancy makes using `LazyUpdate` more robust.