### PR TITLE
Fully qualify derive(Component) default storage

### DIFF
--- a/specs-derive/Cargo.toml
+++ b/specs-derive/Cargo.toml
@@ -14,5 +14,13 @@ proc-macro2 = "1.0.8"
 syn = "1.0.14"
 quote = "1.0.2"
 
+[dev-dependencies]
+static_assertions = "1.1.0"
+
+[dev-dependencies.specs]
+version = "0.16.1"
+path = ".."
+features = ["specs-derive"]
+
 [lib]
 proc-macro = true

--- a/specs-derive/src/lib.rs
+++ b/specs-derive/src/lib.rs
@@ -66,7 +66,7 @@ fn impl_component(ast: &DeriveInput) -> proc_macro2::TokenStream {
                 .unwrap()
                 .storage
         })
-        .unwrap_or_else(|| parse_quote!(DenseVecStorage));
+        .unwrap_or_else(|| parse_quote!(::specs::storage::DenseVecStorage));
 
     quote! {
         impl #impl_generics Component for #name #ty_generics #where_clause {

--- a/specs-derive/tests/default.rs
+++ b/specs-derive/tests/default.rs
@@ -1,0 +1,6 @@
+use specs::Component;
+
+#[derive(Component)]
+pub struct Foo;
+
+static_assertions::assert_type_eq_all!(<Foo as Component>::Storage, ::specs::storage::DenseVecStorage<Foo>);


### PR DESCRIPTION
## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* I did not add any new features, so demo/book/docs do not need updating

## API changes
Users can now `derive(Component)` without `#[storage]` without explicitly importing `DenseVecStorage` elsewhere.