### PR TITLE
update to crossbeam-queue 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ autobenches = false
 travis-ci = { repository = "slide-rs/specs" }
 
 [dependencies]
-crossbeam-queue = "0.2.1"
+crossbeam-queue = "0.3"
 hashbrown = "0.7.0"
 hibitset = { version = "0.6.3", default-features = false }
 log = "0.4.8"

--- a/src/world/lazy.rs
+++ b/src/world/lazy.rs
@@ -382,7 +382,7 @@ impl LazyUpdate {
     }
 
     pub(super) fn maintain(&self, world: &mut World) {
-        while let Ok(l) = self.queue.0.pop() {
+        while let Some(l) = self.queue.0.pop() {
             l.update(world);
         }
     }
@@ -391,6 +391,6 @@ impl LazyUpdate {
 impl Drop for LazyUpdate {
     fn drop(&mut self) {
         // TODO: remove as soon as leak is fixed in crossbeam
-        while self.queue.0.pop().is_ok() {}
+        while self.queue.0.pop().is_some() {}
     }
 }


### PR DESCRIPTION
Question: should delete "// TODO: remove as soon as leak is fixed in crossbeam"?

## API changes

no breaking api changes
