### PR TITLE
Added DerefFlaggedStorage to allow for more precise flagged storage events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ stdweb = ["uuid/stdweb"]
 wasm-bindgen = ["uuid/wasm-bindgen"]
 storage-event-control = []
 derive = ["shred-derive", "specs-derive"]
+nightly = []
 
 shred-derive = ["shred/shred-derive"]
 

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -412,9 +412,9 @@ impl<J: Join> std::iter::Iterator for JoinIter<J> {
 }
 
 /// Clones the `JoinIter`.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```
 /// # use specs::prelude::*;
 /// # #[derive(Debug)]
@@ -432,13 +432,13 @@ impl<J: Join> std::iter::Iterator for JoinIter<J> {
 ///         .create_entity()
 ///         .with(Position)
 ///         .with(Collider)
-///         .build();   
+///         .build();
 /// }
 ///
 /// // check for collisions between entities
 /// let positions = world.read_storage::<Position>();
 /// let colliders = world.read_storage::<Collider>();
-/// 
+///
 /// let mut join_iter = (&positions, &colliders).join();
 /// while let Some(a) = join_iter.next() {
 ///     for b in join_iter.clone() {
@@ -449,22 +449,22 @@ impl<J: Join> std::iter::Iterator for JoinIter<J> {
 ///     }
 /// }
 /// ```
-/// 
+///
 /// It is *not* possible to clone a `JoinIter` which allows for
 /// mutation of its content, as this would lead to shared mutable
 /// access.
-/// 
+///
 /// ```compile_fail
 /// # use specs::prelude::*;
 /// # #[derive(Debug)]
 /// # struct Position; impl Component for Position { type Storage = VecStorage<Self>; }
 /// # let mut world = World::new();
 /// # world.register::<Position>();
-/// # let entity = world.create_entity().with(Position).build();  
+/// # let entity = world.create_entity().with(Position).build();
 /// // .. previous example
-/// 
+///
 /// let mut positions = world.write_storage::<Position>();
-/// 
+///
 /// let mut join_iter = (&mut positions).join();
 /// // this must not compile, as the following line would cause
 /// // undefined behavior!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![feature(generic_associated_types, associated_type_defaults)]
 
 //! # SPECS Parallel ECS
 //!
@@ -224,7 +225,7 @@ pub use crate::{
     changeset::ChangeSet,
     join::Join,
     storage::{
-        DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage,
+        DefaultVecStorage, DenseVecStorage, DerefFlaggedStorage, FlaggedStorage, HashMapStorage, NullStorage,
         ReadStorage, Storage, Tracked, VecStorage, WriteStorage,
     },
     world::{Builder, Component, Entities, Entity, EntityBuilder, LazyUpdate, WorldExt},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![warn(missing_docs)]
-#![feature(generic_associated_types, associated_type_defaults)]
+#![cfg_attr(feature = "nightly", feature(generic_associated_types, associated_type_defaults))]
 
 //! # SPECS Parallel ECS
 //!
@@ -225,8 +225,11 @@ pub use crate::{
     changeset::ChangeSet,
     join::Join,
     storage::{
-        DefaultVecStorage, DenseVecStorage, DerefFlaggedStorage, FlaggedStorage, HashMapStorage, NullStorage,
+        DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage,
         ReadStorage, Storage, Tracked, VecStorage, WriteStorage,
     },
     world::{Builder, Component, Entities, Entity, EntityBuilder, LazyUpdate, WorldExt},
 };
+
+#[cfg(feature = "nightly")]
+pub use crate::storage::DerefFlaggedStorage;

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -1,0 +1,141 @@
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
+
+use hibitset::BitSetLike;
+
+use crate::{
+    storage::{ComponentEvent, DenseVecStorage, Tracked, TryDefault, UnprotectedStorage},
+    world::{Component, Index},
+};
+
+use shrev::EventChannel;
+
+/// Wrapper storage that tracks modifications, insertions, and removals of
+/// components through an `EventChannel`, in a similar manner to `FlaggedStorage`.
+///
+/// Unlike `FlaggedStorage`, this storage uses a wrapper type for mutable
+/// accesses that only emits modification events when the component is actually
+/// used mutably. This means that simply performing a mutable join or calling
+/// `WriteStorage::get_mut` will not, by itself, trigger a modification event.
+pub struct DerefFlaggedStorage<C, T = DenseVecStorage<C>> {
+    channel: EventChannel<ComponentEvent>,
+    storage: T,
+    #[cfg(feature = "storage-event-control")]
+    event_emission: bool,
+    phantom: PhantomData<C>,
+}
+
+impl<C, T> DerefFlaggedStorage<C, T> {
+    #[cfg(feature = "storage-event-control")]
+    fn emit_event(&self) -> bool {
+        self.event_emission
+    }
+
+    #[cfg(not(feature = "storage-event-control"))]
+    fn emit_event(&self) -> bool {
+        true
+    }
+}
+
+impl<C, T> Default for DerefFlaggedStorage<C, T>
+where
+    T: TryDefault,
+{
+    fn default() -> Self {
+        Self {
+            channel: EventChannel::<ComponentEvent>::default(),
+            storage: T::unwrap_default(),
+            #[cfg(feature = "storage-event-control")]
+            event_emission: true,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlaggedStorage<C, T> {
+    type AccessMut<'a> where T: 'a = FlaggedAccessMut<'a, <T as UnprotectedStorage<C>>::AccessMut<'a>, C>;
+
+    unsafe fn clean<B>(&mut self, has: B)
+    where
+        B: BitSetLike,
+    {
+        self.storage.clean(has);
+    }
+
+    unsafe fn get(&self, id: Index) -> &C {
+        self.storage.get(id)
+    }
+
+    unsafe fn get_mut(&mut self, id: Index) -> Self::AccessMut<'_> {
+        let emit = self.emit_event();
+        FlaggedAccessMut {
+            channel: &mut self.channel,
+            emit,
+            id,
+            access: self.storage.get_mut(id),
+            phantom: PhantomData,
+        }
+    }
+
+    unsafe fn insert(&mut self, id: Index, comp: C) {
+        if self.emit_event() {
+            self.channel.single_write(ComponentEvent::Inserted(id));
+        }
+        self.storage.insert(id, comp);
+    }
+
+    unsafe fn remove(&mut self, id: Index) -> C {
+        if self.emit_event() {
+            self.channel.single_write(ComponentEvent::Removed(id));
+        }
+        self.storage.remove(id)
+    }
+}
+
+impl<C, T> Tracked for DerefFlaggedStorage<C, T> {
+    fn channel(&self) -> &EventChannel<ComponentEvent> {
+        &self.channel
+    }
+
+    fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent> {
+        &mut self.channel
+    }
+
+    #[cfg(feature = "storage-event-control")]
+    fn set_event_emission(&mut self, emit: bool) {
+        self.event_emission = emit;
+    }
+
+    #[cfg(feature = "storage-event-control")]
+    fn event_emission(&self) -> bool {
+        self.event_emission
+    }
+}
+
+pub struct FlaggedAccessMut<'a, A, C> {
+    channel: &'a mut EventChannel<ComponentEvent>,
+    emit: bool,
+    id: Index,
+    access: A,
+    phantom: PhantomData<C>,
+}
+
+impl<'a, A, C> Deref for FlaggedAccessMut<'a, A, C>
+    where A: Deref<Target = C>
+{
+    type Target = C;
+    fn deref(&self) -> &Self::Target { self.access.deref() }
+}
+
+impl<'a, A, C> DerefMut for FlaggedAccessMut<'a, A, C>
+    where A: DerefMut<Target = C>
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        if self.emit {
+            self.channel.single_write(ComponentEvent::Modified(self.id));
+        }
+        self.access.deref_mut()
+    }
+}

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -191,7 +191,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Get a mutable reference to the component associated with the entity.
-    pub fn get_mut(&mut self) -> &mut T {
+    pub fn get_mut(&mut self) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'_> {
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -199,7 +199,7 @@ where
 
     /// Converts the `OccupiedEntry` into a mutable reference bounded by
     /// the storage's lifetime.
-    pub fn into_mut(self) -> &'a mut T {
+    pub fn into_mut(self) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -207,7 +207,7 @@ where
 
     /// Inserts a value into the storage and returns the old one.
     pub fn insert(&mut self, mut component: T) -> T {
-        std::mem::swap(&mut component, self.get_mut());
+        std::mem::swap(&mut component, self.get_mut().deref_mut());
         component
     }
 
@@ -230,7 +230,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Inserts a value into the storage.
-    pub fn insert(self, component: T) -> &'a mut T {
+    pub fn insert(self, component: T) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
         self.storage.data.mask.add(self.id);
         // SAFETY: This is safe since we added `self.id` to the mask.
         unsafe {
@@ -267,7 +267,7 @@ where
     }
 
     /// Inserts a component if the entity does not have it already.
-    pub fn or_insert(self, component: T) -> &'a mut T {
+    pub fn or_insert(self, component: T) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
         self.or_insert_with(|| component)
     }
 
@@ -275,7 +275,7 @@ where
     /// when inserting the component. Ensures this entry has a value and if not,
     /// inserts one using the result of the passed closure. Returns a reference
     /// to the value afterwards.
-    pub fn or_insert_with<F>(self, default: F) -> &'a mut T
+    pub fn or_insert_with<F>(self, default: F) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a>
     where
         F: FnOnce() -> T,
     {

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -191,7 +191,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Get a mutable reference to the component associated with the entity.
-    pub fn get_mut(&mut self) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'_> {
+    pub fn get_mut(&mut self) -> AccessMutReturn<'_, T> {
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -199,7 +199,7 @@ where
 
     /// Converts the `OccupiedEntry` into a mutable reference bounded by
     /// the storage's lifetime.
-    pub fn into_mut(self) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
+    pub fn into_mut(self) -> AccessMutReturn<'a, T> {
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -230,7 +230,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     /// Inserts a value into the storage.
-    pub fn insert(self, component: T) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
+    pub fn insert(self, component: T) -> AccessMutReturn<'a, T> {
         self.storage.data.mask.add(self.id);
         // SAFETY: This is safe since we added `self.id` to the mask.
         unsafe {
@@ -267,7 +267,7 @@ where
     }
 
     /// Inserts a component if the entity does not have it already.
-    pub fn or_insert(self, component: T) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a> {
+    pub fn or_insert(self, component: T) -> AccessMutReturn<'a, T> {
         self.or_insert_with(|| component)
     }
 
@@ -275,7 +275,7 @@ where
     /// when inserting the component. Ensures this entry has a value and if not,
     /// inserts one using the result of the passed closure. Returns a reference
     /// to the value afterwards.
-    pub fn or_insert_with<F>(self, default: F) -> <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a>
+    pub fn or_insert_with<F>(self, default: F) -> AccessMutReturn<'a, T>
     where
         F: FnOnce() -> T,
     {

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -200,6 +200,8 @@ where
 }
 
 impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T> {
+    type AccessMut<'a> where T: 'a = <T as UnprotectedStorage<C>>::AccessMut<'a>;
+
     unsafe fn clean<B>(&mut self, has: B)
     where
         B: BitSetLike,
@@ -211,7 +213,7 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedSt
         self.storage.get(id)
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut C {
+    unsafe fn get_mut(&mut self, id: Index) -> Self::AccessMut<'_> {
         if self.emit_event() {
             self.channel.single_write(ComponentEvent::Modified(id));
         }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,7 +4,6 @@ pub use self::{
     data::{ReadStorage, WriteStorage},
     entry::{Entries, OccupiedEntry, StorageEntry, VacantEntry},
     flagged::FlaggedStorage,
-    deref_flagged::DerefFlaggedStorage,
     generic::{GenericReadStorage, GenericWriteStorage},
     restrict::{
         ImmutableParallelRestriction, MutableParallelRestriction, RestrictedStorage,
@@ -15,6 +14,8 @@ pub use self::{
     },
     track::{ComponentEvent, Tracked},
 };
+#[cfg(feature = "nightly")]
+pub use self::deref_flagged::DerefFlaggedStorage;
 
 use self::storages::SliceAccess;
 
@@ -41,6 +42,7 @@ mod data;
 mod drain;
 mod entry;
 mod flagged;
+#[cfg(feature = "nightly")]
 mod deref_flagged;
 mod generic;
 mod restrict;
@@ -48,6 +50,11 @@ mod storages;
 #[cfg(test)]
 mod tests;
 mod track;
+
+#[cfg(feature = "nightly")]
+type AccessMutReturn<'a, T> = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a>;
+#[cfg(not(feature = "nightly"))]
+type AccessMutReturn<'a, T> = &'a mut T;
 
 /// An inverted storage type, only useful to iterate entities
 /// that do not have a particular component type.
@@ -321,7 +328,7 @@ where
     }
 
     /// Tries to mutate the data associated with an `Entity`.
-    pub fn get_mut(&mut self, e: Entity) -> Option<<<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'_>> {
+    pub fn get_mut(&mut self, e: Entity) -> Option<AccessMutReturn<'_, T> > {
         if self.data.mask.contains(e.id()) && self.entities.is_alive(e) {
             // SAFETY: We checked the mask, so all invariants are met.
             Some(unsafe { self.data.inner.get_mut(e.id()) })
@@ -444,7 +451,7 @@ where
     D: DerefMut<Target = MaskedStorage<T>>,
 {
     type Mask = &'a BitSet;
-    type Type = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'a>;
+    type Type = AccessMutReturn<'a, T>;
     type Value = &'a mut T::Storage;
 
     // SAFETY: No unsafe code and no invariants to fulfill.
@@ -499,6 +506,7 @@ where
 /// Used by the framework to quickly join components.
 pub trait UnprotectedStorage<T>: TryDefault {
     /// The wrapper through with mutable access of a component is performed.
+    #[cfg(feature = "nightly")]
     type AccessMut<'a>: DerefMut<Target=T> where Self: 'a;
 
     /// Clean the storage given a bitset with bits set for valid indices.
@@ -536,7 +544,22 @@ pub trait UnprotectedStorage<T>: TryDefault {
     ///
     /// A mask should keep track of those states, and an `id` being contained
     /// in the tracking mask is sufficient to call this method.
+    #[cfg(feature = "nightly")]
     unsafe fn get_mut(&mut self, id: Index) -> Self::AccessMut<'_>;
+
+    /// Tries mutating the data associated with an `Index`.
+    /// This is unsafe because the external set used
+    /// to protect this storage is absent.
+    ///
+    /// # Safety
+    ///
+    /// May only be called after a call to `insert` with `id` and
+    /// no following call to `remove` with `id`.
+    ///
+    /// A mask should keep track of those states, and an `id` being contained
+    /// in the tracking mask is sufficient to call this method.
+    #[cfg(not(feature = "nightly"))]
+    unsafe fn get_mut(&mut self, id: Index) -> &mut T;
 
     /// Inserts new data for a given `Index`.
     ///

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -12,7 +12,7 @@ use crate::join::Join;
 #[cfg(feature = "parallel")]
 use crate::join::ParJoin;
 use crate::{
-    storage::{MaskedStorage, Storage, UnprotectedStorage},
+    storage::{MaskedStorage, Storage, UnprotectedStorage, AccessMutReturn},
     world::{Component, EntitiesRes, Entity, Index},
 };
 
@@ -248,7 +248,7 @@ where
 {
     /// Gets the component related to the current entry without checking whether
     /// the storage has it or not.
-    pub fn get_mut_unchecked(&mut self) -> <<C as Component>::Storage as UnprotectedStorage<C>>::AccessMut<'_> {
+    pub fn get_mut_unchecked(&mut self) -> AccessMutReturn<'_, C>  {
         unsafe { self.storage.borrow_mut().get_mut(self.index) }
     }
 }
@@ -289,7 +289,7 @@ where
     /// This only works if this is a non-parallel `RestrictedStorage`,
     /// otherwise you could access the same component mutably in two different
     /// threads.
-    pub fn get_mut(&mut self, entity: Entity) -> Option<<<C as Component>::Storage as UnprotectedStorage<C>>::AccessMut<'_>> {
+    pub fn get_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, C>> {
         if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
             Some(unsafe { self.storage.borrow_mut().get_mut(entity.id()) })
         } else {

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -248,7 +248,7 @@ where
 {
     /// Gets the component related to the current entry without checking whether
     /// the storage has it or not.
-    pub fn get_mut_unchecked(&mut self) -> &mut C {
+    pub fn get_mut_unchecked(&mut self) -> <<C as Component>::Storage as UnprotectedStorage<C>>::AccessMut<'_> {
         unsafe { self.storage.borrow_mut().get_mut(self.index) }
     }
 }
@@ -289,7 +289,7 @@ where
     /// This only works if this is a non-parallel `RestrictedStorage`,
     /// otherwise you could access the same component mutably in two different
     /// threads.
-    pub fn get_mut(&mut self, entity: Entity) -> Option<&mut C> {
+    pub fn get_mut(&mut self, entity: Entity) -> Option<<<C as Component>::Storage as UnprotectedStorage<C>>::AccessMut<'_>> {
         if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
             Some(unsafe { self.storage.borrow_mut().get_mut(entity.id()) })
         } else {

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -32,6 +32,7 @@ impl<T> Default for BTreeStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -72,6 +73,7 @@ impl<T> Default for HashMapStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -151,6 +153,7 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -207,6 +210,7 @@ impl<T> UnprotectedStorage<T> for NullStorage<T>
 where
     T: Default,
 {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -276,6 +280,7 @@ impl<T> SliceAccess<T> for VecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for VecStorage<T> {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, has: B)
@@ -340,6 +345,7 @@ impl<T> UnprotectedStorage<T> for DefaultVecStorage<T>
 where
     T: Default,
 {
+    #[cfg(feature = "nightly")]
     type AccessMut<'a> where T: 'a = &'a mut T;
 
     unsafe fn clean<B>(&mut self, _has: B)

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -32,6 +32,8 @@ impl<T> Default for BTreeStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -70,6 +72,8 @@ impl<T> Default for HashMapStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -147,6 +151,8 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -201,6 +207,8 @@ impl<T> UnprotectedStorage<T> for NullStorage<T>
 where
     T: Default,
 {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
@@ -268,6 +276,8 @@ impl<T> SliceAccess<T> for VecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for VecStorage<T> {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, has: B)
     where
         B: BitSetLike,
@@ -330,6 +340,8 @@ impl<T> UnprotectedStorage<T> for DefaultVecStorage<T>
 where
     T: Default,
 {
+    type AccessMut<'a> where T: 'a = &'a mut T;
+
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,


### PR DESCRIPTION
This PR is extremely experimental and should not be considered a candidate for merging at the current time. It makes use of highly experimental nightly Rust features and introduces breaking API changes. I am opening it here to make others aware of it and encourage discussion about it.

This PR makes significant changes to the storage traits and introduces, via GATs (Generic Associated Types) the ability for storages to provide a wrapper type to systems that access them instead of simple mutable references.

This has the advantage that it allows storages to detect usage of the wrapper more precisely via the `Deref`/`DerefMut` traits. I have used this fact to implement a significantly more precise version of `FlaggedStorage` known as `DerefFlaggedStorage` that only emits component modification when the component is actually accessed mutably, rather than simply joined upon or accessed via `get_mut`.

The eventual goal of this change is to significantly reduce the bandwidth requirements of Veloren without harming the usability of SPECS or making significant changes to Veloren's codebase.

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

The API of `WriteStorage`, UnprotectedStorage`, and several other traits/types have been changed in a breaking way by this PR.

In addition, the PR requires GATs, which are a nightly feature.