### PR TITLE
Track entity generation in ComponentEvent (fixes #720)

### DIFF
--- a/examples/ordered_track.rs
+++ b/examples/ordered_track.rs
@@ -38,13 +38,12 @@ impl<'a> System<'a> for SysA {
         // the events in order to see the final result of the component. Partial
         // iteration over the events might lead to weird bugs and issues.
         for event in events {
-            match event {
-                ComponentEvent::Modified(id) => {
-                    let entity = entities.entity(*id);
+            match *event {
+                ComponentEvent::Modified(entity) => {
                     if let Some(component) = tracked.get(entity) {
                         // This is safe because it can only occur after an `Inserted` event, not a
                         // `Removed` event.
-                        *self.cache.get_mut(id).unwrap() = (entity, component.0);
+                        *self.cache.get_mut(&entity.id()).unwrap() = (entity, component.0);
                         println!("{:?} was changed to {:?}", entity, component.0);
                     } else {
                         println!(
@@ -53,10 +52,9 @@ impl<'a> System<'a> for SysA {
                         );
                     }
                 }
-                ComponentEvent::Inserted(id) => {
-                    let entity = entities.entity(*id);
+                ComponentEvent::Inserted(entity) => {
                     if let Some(component) = tracked.get(entity) {
-                        self.cache.insert(*id, (entity, component.0));
+                        self.cache.insert(entity.id(), (entity, component.0));
                         println!("{:?} had {:?} inserted", entity, component.0);
                     } else {
                         println!(
@@ -65,9 +63,8 @@ impl<'a> System<'a> for SysA {
                         );
                     }
                 }
-                ComponentEvent::Removed(id) => {
-                    let entity = entities.entity(*id);
-                    self.cache.remove(id);
+                ComponentEvent::Removed(entity) => {
+                    self.cache.remove(&entity.id());
                     println!("{:?} had its component removed", entity);
                 }
             }

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -36,14 +36,14 @@ impl<'a> System<'a> for SysA {
             .read(self.reader_id.as_mut().expect("ReaderId not found"));
         for event in events {
             match event {
-                ComponentEvent::Modified(id) => {
-                    self.modified.add(*id);
+                ComponentEvent::Modified(entity) => {
+                    self.modified.add(entity.id());
                 }
-                ComponentEvent::Inserted(id) => {
-                    self.inserted.add(*id);
+                ComponentEvent::Inserted(entity) => {
+                    self.inserted.add(entity.id());
                 }
-                ComponentEvent::Removed(id) => {
-                    self.removed.add(*id);
+                ComponentEvent::Removed(entity) => {
+                    self.removed.add(entity.id());
                 }
             }
         }

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -9,7 +9,7 @@ use hibitset::{AtomicBitSet, BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr,
 use crate::join::Join;
 #[cfg(feature = "parallel")]
 use crate::join::ParJoin;
-use crate::world::Index;
+use crate::world::{Index, Entity};
 
 macro_rules! define_bit_join {
     ( impl < ( $( $lifetime:tt )* ) ( $( $arg:ident ),* ) > for $bitset:ty ) => {
@@ -26,8 +26,8 @@ macro_rules! define_bit_join {
             }
 
             // SAFETY: No unsafe code and no invariants to meet.
-            unsafe fn get(_: &mut Self::Value, id: Index) -> Self::Type {
-                id
+            unsafe fn get(_: &mut Self::Value, entity: Entity) -> Self::Type {
+                entity.id()
             }
         }
 

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -2,7 +2,7 @@
 
 use std::{iter::FromIterator, ops::AddAssign};
 
-use crate::{prelude::*, storage::UnprotectedStorage, world::Index};
+use crate::{prelude::*, storage::UnprotectedStorage};
 
 /// Change set that can be collected from an iterator, and joined on for easy
 /// application to components.
@@ -64,12 +64,12 @@ impl<T> ChangeSet<T> {
         if self.mask.contains(entity.id()) {
             // SAFETY: we checked the mask, thus it's safe to call
             unsafe {
-                *self.inner.get_mut(entity.id()) += value;
+                *self.inner.get_mut(entity) += value;
             }
         } else {
             // SAFETY: we checked the mask, thus it's safe to call
             unsafe {
-                self.inner.insert(entity.id(), value);
+                self.inner.insert(entity, value);
             }
             self.mask.add(entity.id());
         }
@@ -124,9 +124,9 @@ impl<'a, T> Join for &'a mut ChangeSet<T> {
     // SAFETY: No unsafe code and no invariants to meet.
     // `DistinctStorage` invariants are also met, but no `ParJoin` implementation
     // exists yet.
-    unsafe fn get(v: &mut Self::Value, id: Index) -> Self::Type {
+    unsafe fn get(v: &mut Self::Value, entity: Entity) -> Self::Type {
         let value: *mut Self::Value = v as *mut Self::Value;
-        (*value).get_mut(id)
+        (*value).get_mut(entity)
     }
 }
 
@@ -143,8 +143,8 @@ impl<'a, T> Join for &'a ChangeSet<T> {
     // SAFETY: No unsafe code and no invariants to meet.
     // `DistinctStorage` invariants are also met, but no `ParJoin` implementation
     // exists yet.
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
-        value.get(id)
+    unsafe fn get(value: &mut Self::Value, entity: Entity) -> Self::Type {
+        value.get(entity)
     }
 }
 
@@ -163,8 +163,8 @@ impl<T> Join for ChangeSet<T> {
     // SAFETY: No unsafe code and no invariants to meet.
     // `DistinctStorage` invariants are also met, but no `ParJoin` implementation
     // exists yet.
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
-        value.remove(id)
+    unsafe fn get(value: &mut Self::Value, entity: Entity) -> Self::Type {
+        value.remove(entity)
     }
 }
 

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -1,6 +1,11 @@
 use hibitset::BitSet;
 
-use crate::{join::Join, storage::MaskedStorage, world::Component, Entity};
+use crate::{
+    join::Join,
+    storage::MaskedStorage,
+    world::Component,
+    Entity,
+};
 
 /// A draining storage wrapper which has a `Join` implementation
 /// that removes the components.

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -1,10 +1,6 @@
 use hibitset::BitSet;
 
-use crate::{
-    join::Join,
-    storage::MaskedStorage,
-    world::{Component, Index},
-};
+use crate::{join::Join, storage::MaskedStorage, world::Component, Entity};
 
 /// A draining storage wrapper which has a `Join` implementation
 /// that removes the components.
@@ -29,8 +25,8 @@ where
     }
 
     // SAFETY: No invariants to meet and no unsafe code.
-    unsafe fn get(value: &mut Self::Value, id: Index) -> T {
-        value.remove(id).expect("Tried to access same index twice")
+    unsafe fn get(value: &mut Self::Value, entity: Entity) -> T {
+        value.remove(entity).expect("Tried to access same index twice")
     }
 }
 

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -924,9 +924,9 @@ mod test {
             let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
-                    ComponentEvent::Modified(id) => modified.add(*id),
-                    ComponentEvent::Inserted(id) => inserted.add(*id),
-                    ComponentEvent::Removed(id) => removed.add(*id),
+                    ComponentEvent::Modified(entity) => modified.add(entity.id()),
+                    ComponentEvent::Inserted(entity) => inserted.add(entity.id()),
+                    ComponentEvent::Removed(entity) => removed.add(entity.id()),
                 };
             }
         }
@@ -949,9 +949,9 @@ mod test {
             let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
-                    ComponentEvent::Modified(id) => modified.add(*id),
-                    ComponentEvent::Inserted(id) => inserted.add(*id),
-                    ComponentEvent::Removed(id) => removed.add(*id),
+                    ComponentEvent::Modified(entity) => modified.add(entity.id()),
+                    ComponentEvent::Inserted(entity) => inserted.add(entity.id()),
+                    ComponentEvent::Removed(entity) => removed.add(entity.id()),
                 };
             }
         }
@@ -974,9 +974,9 @@ mod test {
             let events = s1.channel().read(&mut reader_id);
             for event in events {
                 match event {
-                    ComponentEvent::Modified(id) => modified.add(*id),
-                    ComponentEvent::Inserted(id) => inserted.add(*id),
-                    ComponentEvent::Removed(id) => removed.add(*id),
+                    ComponentEvent::Modified(entity) => modified.add(entity.id()),
+                    ComponentEvent::Inserted(entity) => inserted.add(entity.id()),
+                    ComponentEvent::Removed(entity) => removed.add(entity.id()),
                 };
             }
         }

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -5,7 +5,8 @@ use shrev::{EventChannel, ReaderId};
 use crate::{
     join::Join,
     storage::{MaskedStorage, Storage},
-    world::{Component, Index},
+    world::Component,
+    Entity,
 };
 
 /// `UnprotectedStorage`s that track modifications, insertions, and
@@ -33,13 +34,13 @@ pub trait Tracked {
 pub enum ComponentEvent {
     /// An insertion event, note that a modification event will be triggered if
     /// the entity already had a component and had a new one inserted.
-    Inserted(Index),
+    Inserted(Entity),
     /// A modification event, this will be sent any time a component is accessed
     /// mutably so be careful with joins over `&mut storages` as it could
     /// potentially flag all of them.
-    Modified(Index),
+    Modified(Entity),
     /// A removal event.
-    Removed(Index),
+    Removed(Entity),
 }
 
 impl<'e, T, D> Storage<'e, T, D>

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -322,13 +322,8 @@ impl<'a> Join for &'a EntitiesRes {
         (BitSetOr(&self.alloc.alive, &self.alloc.raised), self)
     }
 
-    unsafe fn get(v: &mut &'a EntitiesRes, idx: Index) -> Entity {
-        let gen = v
-            .alloc
-            .generation(idx)
-            .map(|gen| if gen.is_alive() { gen } else { gen.raised() })
-            .unwrap_or_else(Generation::one);
-        Entity(idx, gen)
+    unsafe fn get(v: &mut &'a EntitiesRes, e: Entity) -> Entity {
+        e
     }
 }
 


### PR DESCRIPTION
## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've updated the book to reflect my changes

## API changes

- `ComponentEvent` now contains an `Entity` instead of an `Index`
- `Join::get` works with `Entity`s now
- `JoinIter::get_unchecked` has been removed, since there is no way to obtain generation from a pure function
- `FlaggedAccessMut`, `OccupiedEntry`, `VacantEntry`, and `PairedStorage` all store an `Entity` instead of an `Index`
- `UnprotectedStorage`s now work with `Entity`s instead of `Index`es

## Help needed
There are three remaining compiler errors that I need to fix:

```
   Compiling specs v0.16.1 (/Users/LoganDark/specs)
error[E0308]: mismatched types
  --> src/changeset.rs:83:35
   |
83 |                 self.inner.remove(id);
   |                                   ^^ expected struct `entity::Entity`, found `u32`

error[E0308]: mismatched types
   --> src/join/mod.rs:394:58
    |
394 |             .map(|idx| unsafe { J::get(&mut self.values, idx) })
    |                                                          ^^^ expected struct `entity::Entity`, found `u32`

error[E0308]: mismatched types
   --> src/join/par_join.rs:136:40
    |
136 |             J::get(&mut *values.get(), idx)
    |                                        ^^^ expected struct `entity::Entity`, found `u32`

error: aborting due to 3 previous errors
```

Perhaps those are a sign that this PR is impossible. Perhaps it's a sign that I need someone more skilled than myself to fix the issue.

1. The first compiler error has to do with removing all components from a `ChangeSet`. It iterates through its bitmask and removes every component found inside. The issue is that while it has a bitmask of IDs it does not know the generations for each ID. This will require some more deeper modifications to fix.
2. The second compiler error has to do with the core join logic so it's a bit more complicated. Namely, it's inside the `next` method of `JoinIter`. This iterator not only needs to know the IDs it's iterating over but also the generations. This is complicated to implement because the iterator itself is created from only the bitmask and storage from an implementor of `Join`, which would mean that all implementors of `Join` would have to store generations in addition to the bitmask, which would probably lead to high memory usage and/or inefficiency. Because of the complexity of this issue it's possible that it will prevent this PR from ever being implemented since it would hurt performance and efficiency.
3. The third compiler error is another one like the second, complex enough for us to lose all hope. It has to do with parallel joins and producers and other complex things, so we need to drill through the chain a fair bit to find the root of the issue. We see that a `map` function on `BitIter<J::Mask>` is providing an index but no generation, and that's really all we need to know. It's iterating over a bitmask again with no generation information. We see that the `BitProducer` itself that contains the `BitIter` is stored inside a `JoinProducer`, which is created using the `BitProducer` as a component, which means that the `BitProducer` is what needs to provide generations. Well, the `BitProducer` is first created in `JoinParIter::drive_unindexed` which once again produces the `BitProducer` using only an implementor of `Join`, which brings us back to the exact same issue as the second compiler error. This makes me sad and it makes the compiler sad too and it also probably makes @Imberflur sad.

These issues are so complex and involved that it's entirely possible that the architecture of Specs completely prohibits this feature from being implemented effectively unless every `Join` stored generation information. And no, we can't just not change `Join`s to work with `Entity`s because the `Join` is how you access `FlaggedStorage`s and that's where the `FlaggedStorage` gets information for constructing `ComponentEvent`s.