### PR TITLE
03_dispatcher: fix clippy::unnecessary_mut_passed

### DIFF
--- a/docs/tutorials/src/03_dispatcher.md
+++ b/docs/tutorials/src/03_dispatcher.md
@@ -172,7 +172,7 @@ fn main() {
         .with(HelloWorld, "hello_updated", &["update_pos"])
         .build();
 
-    dispatcher.dispatch(&mut world);
+    dispatcher.dispatch(&world);
     world.maintain();
 }
 ```


### PR DESCRIPTION
Fixes:
```
warning: the method `dispatch` doesn't need a mutable reference
  --> src/main.rs:70:25
   |
70 |     dispatcher.dispatch(&mut world);
   |                         ^^^^^^^^^^
```

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

<!-- Please make it clear if your change is breaking. -->
