### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -38,8 +38,8 @@ where
         'e: 'a,
     {
         if self.entities.is_alive(e) {
+            let entries = self.entries();
             unsafe {
-                let entries = self.entries();
                 // SAFETY: This is safe since we're not swapping out the mask or the values.
                 let (_, mut value): (BitSetAll, _) = entries.open();
                 // SAFETY: We did check the mask, because the mask is `BitSetAll` and every


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

<!-- Please make it clear if your change is breaking. -->
In this function you use the unsafe keyword for one safe expression.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 