### PR TITLE
Safety

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.default-miri]
+slow-timeout = { period = "30s", terminate-after = 1 }
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        toolchain: [stable, beta, nightly, 1.65.0]
+        toolchain: [stable, beta, nightly, 1.70.0]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-latest]
         toolchain: [stable, beta, nightly, 1.65.0]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # install the toolchain we are going to compile and test with
       - name: install ${{ matrix.toolchain }} toolchain
@@ -77,3 +77,18 @@ jobs:
 
       # - run: mdbook test -L ./target/debug/deps docs/book
       #   if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
+
+  miri:
+    name: "Miri"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          rustup override set nightly
+          cargo miri setup
+      - name: Install latest nextest release
+        uses: taiki-e/install-action@nextest
+      - name: Test with Miri
+        run: ./miri.sh

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -15,13 +15,11 @@ jobs:
           - bans licenses sources
 
     # Prevent sudden announcement of a new advisory from failing ci:
-    # continue-on-error: ${{ matrix.checks == 'advisories' }}
-    # TODO: temp to allow git deps
-    continue-on-error: true
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
           command: check ${{ matrix.checks }}

--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -15,7 +15,10 @@ jobs:
           - bans licenses sources
 
     # Prevent sudden announcement of a new advisory from failing ci:
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
+    # continue-on-error: ${{ matrix.checks == 'advisories' }}
+    # TODO: temp to allow git deps
+    continue-on-error: true
+
 
     steps:
       - uses: actions/checkout@v2

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,9 +1,8 @@
 hard_tabs = false
-imports_granularity = "Crate"
 reorder_impl_items = true
 use_field_init_shorthand = true
 use_try_shorthand = true
 format_code_in_doc_comments = true
 wrap_comments = true
-edition = "2018"
+edition = "2021"
 version = "Two"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
+# Unreleased
+
+* MSRV to 1.65.0 [#7xx].
+
+[#7xx]: https://github.com/amethyst/specs/pull/7xx
+
 # 0.19.0 (2023-06-10)
 
 * Bump MSRV to 1.65.0 ([#766])
 * Added index where entity deletion stopped to the error returned from `WorldExt::delete_entities` ([#766])
 * Fix bug where deleting an entity with the wrong generation could clear the components of an existing entity. ([#766])
-* Bump shred to version `0.14.1`, MSRV to 1.60.0 ([shred changelog][shred-changelog], [#756])
+* Bump shred to version `0.14.1`, MSRV to 1.60.0 ([shred changelog][shred_changelog], [#756])
 
+[shred_changelog]: https://github.com/amethyst/shred/blob/master/CHANGELOG.md#0141-2022-07-14
 [#756]: https://github.com/amethyst/specs/pull/756
 [#766]: https://github.com/amethyst/specs/pull/766
-[shred-changelog]: https://github.com/amethyst/shred/blob/6b754812e304cf6c63ba0364a82a7e0e5025aaa4/CHANGELOG.md#0140-2022-07-12
 
 # 0.18.0 (2022-07-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Unreleased
 
-* MSRV to 1.70.0 [#7xx].
+* MSRV to 1.70.0 ([#765])
+* Significant refactor of `Join` and related traits to alleviate soundness
+  issues. Includes introduction of a lending/streaming join via the `LendJoin`
+  trait which is the new common denominator implemented by joinable types.
+  ([#765])
 
-[#7xx]: https://github.com/amethyst/specs/pull/7xx
+[#765]: https://github.com/amethyst/specs/pull/765
 
 # 0.19.0 (2023-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* MSRV to 1.65.0 [#7xx].
+* MSRV to 1.70.0 [#7xx].
 
 [#7xx]: https://github.com/amethyst/specs/pull/7xx
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,26 +62,27 @@ shred = { git = "https://github.com/Imberflur/shred", branch = "metatable-fix", 
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]
+name = "async"
+[[example]]
 name = "basic"
-
-[[example]]
-name = "full"
-
-[[example]]
-name = "cluster_bomb"
-
 [[example]]
 name = "bitset"
-
 [[example]]
-name = "track"
-
+name = "cluster_bomb"
+[[example]]
+name = "full"
+[[example]]
+name = "lend_join"
+test = true
 [[example]]
 name = "ordered_track"
-
 [[example]]
 name = "saveload"
 required-features = ["serde"]
+[[example]]
+name = "slices"
+[[example]]
+name = "track"
 
 [[bench]]
 name = "benches_main"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ ahash = "0.7.6"
 crossbeam-queue = "0.3"
 # waiting on PR and new version to be published
 # hibitset = { version = "0.6.3", default-features = false }
-hibitset = { path = "../hibitset", default-features = false }
+hibitset = { git = "https://github.com/amethyst/hibitset", default-features = false }
 log = "0.4.8"
 # waiting on PR and new version to be published
 # shred = { version = "0.14.1", default-features = false }
-shred = { path = "../shred", default-features = false }
+shred = { git = "https://github.com/Imberflur/shred", branch = "metatable-fix", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -58,7 +58,7 @@ ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
 # shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
-shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
+shred = { git = "https://github.com/Imberflur/shred", branch = "metatable-fix", default-features = false, features = ["shred-derive"]}
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,9 @@ autobenches = false
 [dependencies]
 ahash = "0.7.6"
 crossbeam-queue = "0.3"
-# waiting on PR and new version to be published
-# hibitset = { version = "0.6.3", default-features = false }
-hibitset = { git = "https://github.com/amethyst/hibitset", default-features = false }
+hibitset = { version = "0.6.4", default-features = false }
 log = "0.4.8"
-# waiting on PR and new version to be published
-# shred = { version = "0.14.1", default-features = false }
-shred = { git = "https://github.com/Imberflur/shred", branch = "metatable-fix", default-features = false }
+shred = { version = "0.15.0", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -58,8 +54,7 @@ criterion = "0.3.1"
 ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
-# shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
-shred = { git = "https://github.com/Imberflur/shred", branch = "metatable-fix", default-features = false, features = ["shred-derive"]}
+shred = { version = "0.15.0", default-features = false, features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ uuid_entity = ["uuid", "serde"]
 stdweb = ["uuid/js"]
 storage-event-control = []
 derive = ["shred-derive", "specs-derive"]
-nightly = []
 
 shred-derive = ["shred/shred-derive"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4.8"
 shred = { version = "0.14.1", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
+nougat = "0.2.3"
 
 rayon = { version = "1.5.1", optional = true }
 serde = { version = "1.0.104", optional = true, features = ["serde_derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ uuid_entity = ["uuid", "serde"]
 stdweb = ["uuid/js"]
 storage-event-control = []
 derive = ["shred-derive", "specs-derive"]
+nightly = ["shred/nightly"]
 
 shred-derive = ["shred/shred-derive"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ ahash = "0.7.6"
 crossbeam-queue = "0.3"
 hibitset = { version = "0.6.3", default-features = false }
 log = "0.4.8"
-shred = { version = "0.14.1", default-features = false }
+# waiting on https://github.com/amethyst/shred/pull/223
+# shred = { version = "0.14.1", default-features = false }
+shred = { path = "../shred", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -54,7 +56,9 @@ criterion = "0.3.1"
 ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
-shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
+# waiting on https://github.com/amethyst/shred/pull/223
+# shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
+shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ autobenches = false
 [dependencies]
 ahash = "0.7.6"
 crossbeam-queue = "0.3"
-# TODO make PR
+# waiting on PR and new version to be published
 # hibitset = { version = "0.6.3", default-features = false }
 hibitset = { path = "../hibitset", default-features = false }
 log = "0.4.8"
-# waiting on https://github.com/amethyst/shred/pull/223
-shred = { version = "0.14.1", default-features = false }
-# shred = { path = "../shred", default-features = false }
+# waiting on PR and new version to be published
+# shred = { version = "0.14.1", default-features = false }
+shred = { path = "../shred", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -57,9 +57,8 @@ criterion = "0.3.1"
 ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
-# waiting on https://github.com/amethyst/shred/pull/223
-shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
-# shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
+# shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
+shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 authors = ["slide-rs hackers"]
 include = ["/src", "/examples", "/benches", "/README.md", "/LICENSE-MIT", "/LICENSE-APACHE"]
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 # the `storage_cmp` and `storage_sparse` benches are called from `benches_main`
 autobenches = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,13 @@ autobenches = false
 [dependencies]
 ahash = "0.7.6"
 crossbeam-queue = "0.3"
-hibitset = { version = "0.6.3", default-features = false }
+# TODO make PR
+# hibitset = { version = "0.6.3", default-features = false }
+hibitset = { path = "../hibitset", default-features = false }
 log = "0.4.8"
 # waiting on https://github.com/amethyst/shred/pull/223
-# shred = { version = "0.14.1", default-features = false }
-shred = { path = "../shred", default-features = false }
+shred = { version = "0.14.1", default-features = false }
+# shred = { path = "../shred", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -56,8 +58,8 @@ ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
 # waiting on https://github.com/amethyst/shred/pull/223
-# shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
-shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
+shred = { version = "0.14.1", default-features = false, features = ["shred-derive"] }
+# shred = { path = "../shred", default-features = false, features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Unlike most other ECS libraries out there, it provides
       other and you can use barriers to force several stages in system execution
 * high performance for real-world applications
 
-Minimum Rust version: 1.65
+Minimum Rust version: 1.70
 
 ## [Link to the book][book]
 

--- a/benches/parallel.rs
+++ b/benches/parallel.rs
@@ -55,6 +55,7 @@ impl Component for Lifetime {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 struct Ball {
     radius: f32,
 }
@@ -64,6 +65,7 @@ impl Component for Ball {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 struct Rect {
     a: f32,
     b: f32,
@@ -91,6 +93,7 @@ impl Component for SpawnRequests {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 struct Collision {
     a: Entity,
     b: Entity,
@@ -102,6 +105,7 @@ impl Component for Collision {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[allow(dead_code)]
 struct Room {
     inner_width: f32,
     inner_height: f32,

--- a/docs/tutorials/src/12_tracked.md
+++ b/docs/tutorials/src/12_tracked.md
@@ -117,8 +117,8 @@ fetch the component as mutable if/when needed.
 for (entity, mut comp) in (&entities, &mut comps.restrict_mut()).join() {
     // Check whether this component should be modified, without fetching it as
     // mutable.
-    if comp.get_unchecked().condition < 5 {
-         let mut comp = comp.get_mut_unchecked();
+    if comp.get().condition < 5 {
+         let mut comp = comp.get_mut();
          // ...
     }
 }

--- a/examples/lend_join.rs
+++ b/examples/lend_join.rs
@@ -10,16 +10,43 @@ fn main() {
 
     world.register::<Pos>();
 
-    world.create_entity().with(Pos(0.0)).build();
+    let entity0 = world.create_entity().with(Pos(0.0)).build();
     world.create_entity().with(Pos(1.6)).build();
     world.create_entity().with(Pos(5.4)).build();
 
     let mut pos = world.write_storage::<Pos>();
+    let entities = world.entities();
 
+    // Unlike `join` the type return from `lend_join` does not implement
+    // `Iterator`. Instead, a `next` method is provided that only allows one
+    // element to be accessed at once.
     let mut lending = (&mut pos).lend_join();
 
+    // We copy the value out here so the borrow of `lending` is released.
     let a = lending.next().unwrap().0;
+    // Here we keep the reference from `lending.next()` alive, so `lending`
+    // remains exclusively borrowed for the lifetime of `b`.
     let b = lending.next().unwrap();
-    // let d = lending.next().unwrap(); (this rightly fails to compile)
-    let _c = a + b.0;
+    // This right fails to compile since `b` is used below:
+    // let d = lending.next().unwrap();
+    b.0 = a;
+
+    // Items can be iterated with `while let` loop:
+    let mut lending = (&mut pos).lend_join();
+    while let Some(pos) = lending.next() {
+        pos.0 *= 1.5;
+    }
+
+    // A `for_each` method is also available:
+    (&mut pos).lend_join().for_each(|pos| {
+        pos.0 += 1.0;
+    });
+
+    // Finally, there is one bonus feature which `.join()` can't soundly provide.
+    let mut lending = (&mut pos).lend_join();
+    // That is, there is a method to get the joined result for a particular
+    // entity:
+    if let Some(pos) = lending.get(entity0, &entities) {
+        pos.0 += 5.0;
+    }
 }

--- a/examples/lend_join.rs
+++ b/examples/lend_join.rs
@@ -1,0 +1,25 @@
+use specs::prelude::*;
+struct Pos(f32);
+
+impl Component for Pos {
+    type Storage = VecStorage<Self>;
+}
+
+fn main() {
+    let mut world = World::new();
+
+    world.register::<Pos>();
+
+    world.create_entity().with(Pos(0.0)).build();
+    world.create_entity().with(Pos(1.6)).build();
+    world.create_entity().with(Pos(5.4)).build();
+
+    let mut pos = world.write_storage::<Pos>();
+
+    let mut lending = (&mut pos).lend_join();
+
+    let a = lending.next().unwrap().0;
+    let b = lending.next().unwrap();
+    // let d = lending.next().unwrap(); (this rightly fails to compile)
+    let _c = a + b.0;
+}

--- a/examples/slices.rs
+++ b/examples/slices.rs
@@ -42,7 +42,7 @@ impl<'a> System<'a> for SysA {
         // Both the `Pos` and `Vel` components use `DefaultVecStorage`, which supports
         // `as_slice()` and `as_mut_slice()`. This lets us access components without
         // indirection.
-        let mut pos_slice = pos.as_mut_slice();
+        let pos_slice = pos.as_mut_slice();
         let vel_slice = vel.as_slice();
 
         // Note that an entity which has position but not velocity will still have

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -70,7 +70,7 @@ impl<'a> System<'a> for SysB {
     fn run(&mut self, (entities, mut tracked): Self::SystemData) {
         for (entity, mut restricted) in (&entities, &mut tracked.restrict_mut()).join() {
             if entity.id() % 2 == 0 {
-                let mut comp = restricted.get_mut();
+                let comp = restricted.get_mut();
                 comp.0 += 1;
             }
         }

--- a/examples/track.rs
+++ b/examples/track.rs
@@ -70,7 +70,7 @@ impl<'a> System<'a> for SysB {
     fn run(&mut self, (entities, mut tracked): Self::SystemData) {
         for (entity, mut restricted) in (&entities, &mut tracked.restrict_mut()).join() {
             if entity.id() % 2 == 0 {
-                let mut comp = restricted.get_mut_unchecked();
+                let mut comp = restricted.get_mut();
                 comp.0 += 1;
             }
         }

--- a/miri.sh
+++ b/miri.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Convenience script for running Miri, also the same one that the CI runs!
+
+# use half the available threads since miri can be a bit memory hungry
+test_threads=$((($(nproc) - 1) / 2 + 1))
+echo using $test_threads threads
+
+# filters out long running tests
+filter='not (test(100k) | test(map_test::wrap) | test(map_test::insert_same_key) | test(=mixed_create_merge)| test(=par_join_many_entities_and_systems) | test(=stillborn_entities))'
+echo "using filter: \"$filter\""
+
+# Miri currently reports leaks in some tests so we disable that check
+# here (might be due to ptr-int-ptr in crossbeam-epoch so might be
+# resolved in future versions of that crate).
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+    cargo +nightly miri nextest run \
+    -E "$filter" \
+    --test-threads="$test_threads" \
+    # use nocapture or run miri directly to see warnings from miri
+    #--nocapture

--- a/miri.sh
+++ b/miri.sh
@@ -2,6 +2,8 @@
 #
 # Convenience script for running Miri, also the same one that the CI runs!
 
+set -e
+
 # use half the available threads since miri can be a bit memory hungry
 test_threads=$((($(nproc) - 1) / 2 + 1))
 echo using $test_threads threads
@@ -19,3 +21,11 @@ MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     --test-threads="$test_threads" \
     # use nocapture or run miri directly to see warnings from miri
     #--nocapture
+
+# Run tests only available when parallel feature is disabled.
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+    cargo +nightly miri nextest run \
+    --no-default-features \
+    -E "binary(no_parallel)" \
+    --test-threads="$test_threads"
+

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -2,8 +2,7 @@
 //!
 //! Normally used for `Join`s and filtering entities.
 
-// TODO: rustfmt bug (probably fixed in next rust release)
-// #![cfg_attr(rustfmt, rustfmt::skip)]
+#![cfg_attr(rustfmt, rustfmt::skip)]
 
 use hibitset::{AtomicBitSet, BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr, BitSetXor};
 

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -7,11 +7,11 @@
 
 use hibitset::{AtomicBitSet, BitSet, BitSetAnd, BitSetLike, BitSetNot, BitSetOr, BitSetXor};
 
-use crate::join::Join;
 #[nougat::gat(Type)]
 use crate::join::LendJoin;
 #[cfg(feature = "parallel")]
 use crate::join::ParJoin;
+use crate::join::{Join, RepeatableLendGet};
 use crate::world::Index;
 
 macro_rules! define_bit_join {
@@ -37,6 +37,12 @@ macro_rules! define_bit_join {
                 id
             }
         }
+
+        // SAFETY: <$biset as LendJoin>::get does not rely on only being called
+        // once with a particular ID
+        unsafe impl<$( $lifetime, )* $( $arg ),*> RepeatableLendGet for $bitset
+            where $( $arg: BitSetLike ),* {}
+
         // SAFETY: `get` just returns the provided `id` (`Self::Value` is `()`
         // and corresponds with any mask instance).
         unsafe impl<$( $lifetime, )* $( $arg ),*> Join for $bitset

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -31,8 +31,7 @@ macro_rules! define_bit_join {
             }
 
             unsafe fn get<'next>(_: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-            where
-                Self: 'next,
+
             {
                 id
             }

--- a/src/bitset.rs
+++ b/src/bitset.rs
@@ -30,7 +30,10 @@ macro_rules! define_bit_join {
                 (self, ())
             }
 
-            unsafe fn get(_: &mut Self::Value, id: Index) -> Self::Type<'_> {
+            unsafe fn get<'next>(_: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+            where
+                Self: 'next,
+            {
                 id
             }
         }

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -115,10 +115,9 @@ where
     }
 }
 
-// TODO: lifetime issues
 // SAFETY: `open` returns references to a mask and storage which are contained
 // together in the `ChangeSet` and correspond.
-/*#[nougat::gat]
+#[nougat::gat]
 unsafe impl<'a, T> LendJoin for &'a mut ChangeSet<T> {
     type Mask = &'a BitSet;
     type Type<'next> = &'next mut T;
@@ -128,12 +127,15 @@ unsafe impl<'a, T> LendJoin for &'a mut ChangeSet<T> {
         (&self.mask, &mut self.inner)
     }
 
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type<'_> {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
         // SAFETY: Since we require that the mask was checked, an element for
         // `id` must have been inserted without being removed.
         unsafe { value.get_mut(id) }
     }
-}*/
+}
 
 // SAFETY: `open` returns references to a mask and storage which are contained
 // together in the `ChangeSet` and correspond.
@@ -161,25 +163,27 @@ unsafe impl<'a, T> Join for &'a mut ChangeSet<T> {
 
 // NOTE: could implement ParJoin for `&'a mut ChangeSet`/`&'a ChangeSet`
 
-// TODO: lifetime issues
 // SAFETY: `open` returns references to a mask and storage which are contained
 // together in the `ChangeSet` and correspond.
-/*#[nougat::gat]
+#[nougat::gat]
 unsafe impl<'a, T> LendJoin for &'a ChangeSet<T> {
     type Mask = &'a BitSet;
-    type Type<'next> = &'next T;
+    type Type<'next> = &'a T;
     type Value = &'a DenseVecStorage<T>;
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
         (&self.mask, &self.inner)
     }
 
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type<'_> {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
         // SAFETY: Since we require that the mask was checked, an element for
         // `i` must have been inserted without being removed.
         unsafe { value.get(id) }
     }
-}*/
+}
 
 // SAFETY: `open` returns references to a mask and storage which are contained
 // together in the `ChangeSet` and correspond.
@@ -199,22 +203,24 @@ unsafe impl<'a, T> Join for &'a ChangeSet<T> {
     }
 }
 
-// S-TODO: implement LendJoin for ChangeSet
-/*
 /// A `Join` implementation for `ChangeSet` that simply removes all the entries
 /// on a call to `get`.
 // SAFETY: `open` returns references to a mask and storage which are contained
 // together in the `ChangeSet` and correspond.
-unsafe impl<T> Join for ChangeSet<T> {
+#[nougat::gat]
+unsafe impl<T> LendJoin for ChangeSet<T> {
     type Mask = BitSet;
-    type Type = T;
+    type Type<'next> = T;
     type Value = DenseVecStorage<T>;
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
         (self.mask, self.inner)
     }
 
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
         // S-TODO: Following the safety requirements of `Join::get`, users can get
         // this to be UB by calling `get` dropping the returned value and
         // calling `get` with the same `id`.
@@ -226,7 +232,7 @@ unsafe impl<T> Join for ChangeSet<T> {
         // SAFETY: S-TODO
         unsafe { value.remove(id) }
     }
-}*/
+}
 
 /// A `Join` implementation for `ChangeSet` that simply removes all the entries
 /// on a call to `get`.

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -157,13 +157,13 @@ unsafe impl<'a, T> Join for &'a mut ChangeSet<T> {
 
     unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
         // SAFETY:
-        // * Since we require that the mask was checked, an element for
-        //   `id` must have been inserted without being removed.
-        // * We also require that there are no subsequent calls with the same
-        //   `id` for this instance of the values from `open`, so there are no
-        //   extant references for the element corresponding to this `id`.
-        // * Since we have an exclusive reference to `Self::Value`, we know this
-        //   isn't being called from multiple threads at once.
+        // * Since we require that the mask was checked, an element for `id` must have
+        //   been inserted without being removed.
+        // * We also require that there are no subsequent calls with the same `id` for
+        //   this instance of the values from `open`, so there are no extant references
+        //   for the element corresponding to this `id`.
+        // * Since we have an exclusive reference to `Self::Value`, we know this isn't
+        //   being called from multiple threads at once.
         unsafe { SharedGetMutOnly::get_mut(value, id) }
     }
 }

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -222,6 +222,10 @@ unsafe impl<'a, T> Join for &'a ChangeSet<T> {
 // together in the `ChangeSet` and correspond. Iterating mask does not repeat
 // indices.
 #[nougat::gat]
+// This is a trait impl so method safety documentation is on the trait
+// definition, maybe nougat confuses clippy? But this is the only spot that has
+// this issue.
+#[allow(clippy::missing_safety_doc)]
 unsafe impl<T> LendJoin for ChangeSet<T> {
     type Mask = BitSet;
     type Type<'next> = T;

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -1,6 +1,3 @@
-// TODO: promote to the whole crate
-#![deny(unsafe_op_in_unsafe_fn)]
-
 //! Provides a changeset that can be collected from an iterator.
 
 use std::{iter::FromIterator, ops::AddAssign};
@@ -161,6 +158,11 @@ impl<T> Join for ChangeSet<T> {
     }
 
     unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
+        // NOTE: Following the safety requirements of `Join::get`, users can get
+        // this to panic by calling `get` dropping the returned value and
+        // calling `get` with the same `id`. However, such a panic isn't
+        // unsound. Also, the current `JoinIter` implementation will never do
+        // this.
         // SAFETY: S-TODO
         unsafe { value.remove(id) }
     }

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -164,7 +164,7 @@ unsafe impl<'a, T> Join for &'a mut ChangeSet<T> {
         //   extant references for the element corresponding to this `id`.
         // * Since we have an exclusive reference to `Self::Value`, we know this
         //   isn't being called from multiple threads at once.
-        unsafe { value.get(id) }
+        unsafe { SharedGetMutOnly::get_mut(value, id) }
     }
 }
 

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -144,7 +144,8 @@ unsafe impl<'a, T> LendJoin for &'a mut ChangeSet<T> {
 unsafe impl<'a, T> RepeatableLendGet for &'a mut ChangeSet<T> {}
 
 // SAFETY: `open` returns references to a mask and storage which are contained
-// together in the `ChangeSet` and correspond.
+// together in the `ChangeSet` and correspond. Iterating mask does not repeat
+// indices.
 unsafe impl<'a, T> Join for &'a mut ChangeSet<T> {
     type Mask = &'a BitSet;
     type Type = &'a mut T;
@@ -158,9 +159,9 @@ unsafe impl<'a, T> Join for &'a mut ChangeSet<T> {
         // SAFETY:
         // * Since we require that the mask was checked, an element for
         //   `id` must have been inserted without being removed.
-        // * We also require that the caller drop the value returned before
-        //   subsequent calls with the same `id`, so there are no extant
-        //   references that were obtained with the same `id`.
+        // * We also require that there are no subsequent calls with the same
+        //   `id` for this instance of the values from `open`, so there are no
+        //   extant references for the element corresponding to this `id`.
         // * Since we have an exclusive reference to `Self::Value`, we know this
         //   isn't being called from multiple threads at once.
         unsafe { value.get(id) }
@@ -197,7 +198,8 @@ unsafe impl<'a, T> LendJoin for &'a ChangeSet<T> {
 unsafe impl<'a, T> RepeatableLendGet for &'a ChangeSet<T> {}
 
 // SAFETY: `open` returns references to a mask and storage which are contained
-// together in the `ChangeSet` and correspond.
+// together in the `ChangeSet` and correspond. Iterating mask does not repeat
+// indices.
 unsafe impl<'a, T> Join for &'a ChangeSet<T> {
     type Mask = &'a BitSet;
     type Type = &'a T;
@@ -251,7 +253,8 @@ unsafe impl<T> LendJoin for ChangeSet<T> {
 /// A `Join` implementation for `ChangeSet` that simply removes all the entries
 /// on a call to `get`.
 // SAFETY: `open` returns references to a mask and storage which are contained
-// together in the `ChangeSet` and correspond.
+// together in the `ChangeSet` and correspond. Iterating mask does not repeat
+// indices.
 unsafe impl<T> Join for ChangeSet<T> {
     type Mask = BitSet;
     type Type = T;

--- a/src/changeset.rs
+++ b/src/changeset.rs
@@ -129,10 +129,7 @@ unsafe impl<'a, T> LendJoin for &'a mut ChangeSet<T> {
         (&self.mask, &mut self.inner)
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // SAFETY: Since we require that the mask was checked, an element for
         // `id` must have been inserted without being removed.
         unsafe { value.get_mut(id) }
@@ -183,10 +180,7 @@ unsafe impl<'a, T> LendJoin for &'a ChangeSet<T> {
         (&self.mask, &self.inner)
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // SAFETY: Since we require that the mask was checked, an element for
         // `id` must have been inserted without being removed.
         unsafe { value.get(id) }
@@ -235,10 +229,7 @@ unsafe impl<T> LendJoin for ChangeSet<T> {
         (self.mask, self.inner)
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // NOTE: This impl is the main reason that `RepeatableLendGet` exists
         // since it moves the value out of the backing storage and thus can't
         // be called multiple times with the same ID!

--- a/src/join/bit_and.rs
+++ b/src/join/bit_and.rs
@@ -1,0 +1,57 @@
+use hibitset::{BitSetAnd, BitSetLike};
+use tuple_utils::Split;
+
+/// `BitAnd` is a helper method to & bitsets together resulting in a tree.
+pub trait BitAnd {
+    /// The combined bitsets.
+    type Value: BitSetLike;
+    /// Combines `Self` into a single `BitSetLike` through `BitSetAnd`.
+    fn and(self) -> Self::Value;
+}
+
+/// This needs to be special cased
+impl<A> BitAnd for (A,)
+where
+    A: BitSetLike,
+{
+    type Value = A;
+
+    fn and(self) -> Self::Value {
+        self.0
+    }
+}
+
+macro_rules! bitset_and {
+    // use variables to indicate the arity of the tuple
+    ($($from:ident),*) => {
+        impl<$($from),*> BitAnd for ($($from),*)
+            where $($from: BitSetLike),*
+        {
+            type Value = BitSetAnd<
+                <<Self as Split>::Left as BitAnd>::Value,
+                <<Self as Split>::Right as BitAnd>::Value
+            >;
+
+            fn and(self) -> Self::Value {
+                let (l, r) = self.split();
+                BitSetAnd(l.and(), r.and())
+            }
+        }
+    }
+}
+
+bitset_and! {A, B}
+bitset_and! {A, B, C}
+bitset_and! {A, B, C, D}
+bitset_and! {A, B, C, D, E}
+bitset_and! {A, B, C, D, E, F}
+bitset_and! {A, B, C, D, E, F, G}
+bitset_and! {A, B, C, D, E, F, G, H}
+bitset_and! {A, B, C, D, E, F, G, H, I}
+bitset_and! {A, B, C, D, E, F, G, H, I, J}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K, L}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K, L, M}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K, L, M, N}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O}
+bitset_and! {A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P}

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -20,7 +20,9 @@ pub unsafe trait LendJoin {
     /// This type is using macro magic to emulate GATs on stable. So to refer to
     /// it you need to use the [`LendJoinType<'next, J>`](LendJoinType) type
     /// alias.
-    type Type<'next>;
+    type Type<'next>
+    where
+        Self: 'next;
     /// Type of joined storages.
     type Value;
     /// Type of joined bit mask.
@@ -116,7 +118,9 @@ pub unsafe trait LendJoin {
     ///
     /// * A call to `get` must be preceded by a check if `id` is part of
     ///   `Self::Mask`
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type<'_>;
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next;
 
     /// If this `LendJoin` typically returns all indices in the mask, then
     /// iterating over only it or combined with other joins that are also

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -139,8 +139,8 @@ pub unsafe trait LendJoin {
 
 /// # Safety
 ///
-/// Implementing this trait guarantees that `<Self as LendJoin>::get` can soundly be called
-/// multiple times with the same ID.
+/// Implementing this trait guarantees that `<Self as LendJoin>::get` can
+/// soundly be called multiple times with the same ID.
 pub unsafe trait RepeatableLendGet: LendJoin {}
 
 /// Type alias to refer to the `<J as LendJoin>::Type<'next>` (except this

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -151,9 +151,7 @@ pub unsafe trait LendJoin {
     /// * Multiple calls with the same `id` are not allowed, for a particular
     ///   instance of the values from [`open`](LendJoin::open). Unless this type
     ///   implements the unsafe trait [`RepeatableLendGet`].
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next;
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>;
 
     /// If this `LendJoin` typically returns all indices in the mask, then
     /// iterating over only it or combined with other joins that are also

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -182,6 +182,7 @@ impl<J: LendJoin> JoinLendIter<J> {
     /// Can be used to iterate with this pattern:
     ///
     /// `while let Some(components) = join_lending_iter.next() {`
+    #[allow(clippy::should_implement_trait)] // we want this to look like iterator
     pub fn next(&mut self) -> Option<LendJoinType<'_, J>> {
         // SAFETY: Since `idx` is yielded from `keys` (the mask), it is
         // necessarily a part of it. `LendJoin` requires that the iterator

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -123,8 +123,6 @@ pub unsafe trait LendJoin {
     /// * Multiple calls with the same `id` are not allowed, for a particular
     ///   instance of the values from [`open`](Join::open). Unless this type
     ///   implements the unsafe trait [`RepeatableLendGet`].
-    ///   (S-TODO update callers to match edit)
-    ///   (S-TODO update immplemetors to match edit)
     unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
     where
         Self: 'next;

--- a/src/join/lend_join.rs
+++ b/src/join/lend_join.rs
@@ -1,0 +1,258 @@
+/// Like the `Join` trait except this is similar to a `LendingIterator` in that
+/// only one item can be accessed at once.
+///
+/// # Safety
+///
+/// The `Self::Mask` value returned with the `Self::Value` must correspond such
+/// that it is safe to retrieve items from `Self::Value` whose presence is
+/// indicated in the mask.
+#[nougat::gat]
+pub unsafe trait LendJoin {
+    /// Type of joined components.
+    ///
+    /// # Note
+    ///
+    /// This type is using macro magic to emulate GATs on stable. So to refer to
+    /// it you need to use the [`LendJoinType<'next, J>`](LendJoinType) type
+    /// alias.
+    type Type<'next>
+    where
+        Self: 'next;
+    /// Type of joined storages.
+    type Value;
+    /// Type of joined bit mask.
+    type Mask: BitSetLike;
+
+    /// Create a joined lending iterator over the contents.
+    fn lend_join(self) -> JoinLendIter<Self>
+    where
+        Self: Sized,
+    {
+        JoinLendIter::new(self)
+    }
+
+    /// Returns a structure that implements `Join`/`LendJoin`/`MaybeJoin` if the
+    /// contained `T` does and that yields all indices, returning `None` for all
+    /// missing elements and `Some(T)` for found elements.
+    ///
+    /// To join over and optional component mutably this pattern can be used:
+    /// `(&mut storage).maybe()`.
+    ///
+    /// WARNING: Do not have a join of only `MaybeJoin`s. Otherwise the join
+    /// will iterate over every single index of the bitset. If you want a
+    /// join with all `MaybeJoin`s, add an `EntitiesRes` to the join as well
+    /// to bound the join to all entities that are alive.
+    ///
+    /// ```
+    /// # use specs::prelude::*;
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Pos { x: i32, y: i32 } impl Component for Pos { type Storage = VecStorage<Self>; }
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Vel { x: i32, y: i32 } impl Component for Vel { type Storage = VecStorage<Self>; }
+    /// struct ExampleSystem;
+    /// impl<'a> System<'a> for ExampleSystem {
+    ///     type SystemData = (
+    ///         WriteStorage<'a, Pos>,
+    ///         ReadStorage<'a, Vel>,
+    ///     );
+    ///     fn run(&mut self, (mut positions, velocities): Self::SystemData) {
+    ///         let mut join = (&mut positions, velocities.maybe()).lend_join();
+    ///         while let Some ((mut position, maybe_velocity)) = join.next() {
+    ///             if let Some(velocity) = maybe_velocity {
+    ///                 position.x += velocity.x;
+    ///                 position.y += velocity.y;
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     let mut world = World::new();
+    ///     let mut dispatcher = DispatcherBuilder::new()
+    ///         .with(ExampleSystem, "example_system", &[])
+    ///         .build();
+    ///
+    ///     dispatcher.setup(&mut world);
+    ///
+    ///     let e1 = world.create_entity()
+    ///         .with(Pos { x: 0, y: 0 })
+    ///         .with(Vel { x: 5, y: 2 })
+    ///         .build();
+    ///
+    ///     let e2 = world.create_entity()
+    ///         .with(Pos { x: 0, y: 0 })
+    ///         .build();
+    ///
+    ///     dispatcher.dispatch(&mut world);
+    ///
+    ///     let positions = world.read_storage::<Pos>();
+    ///     assert_eq!(positions.get(e1), Some(&Pos { x: 5, y: 2 }));
+    ///     assert_eq!(positions.get(e2), Some(&Pos { x: 0, y: 0 }));
+    /// }
+    /// ```
+    fn maybe(self) -> MaybeJoin<Self>
+    where
+        Self: Sized,
+    {
+        MaybeJoin(self)
+    }
+
+    /// Open this join by returning the mask and the storages.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because implementations of this trait can permit the
+    /// `Value` to be mutated independently of the `Mask`. If the `Mask` does
+    /// not correctly report the status of the `Value` then illegal memory
+    /// access can occur.
+    unsafe fn open(self) -> (Self::Mask, Self::Value);
+
+    /// Get a joined component value by a given index.
+    ///
+    /// # Safety
+    ///
+    /// * A call to `get` must be preceded by a check if `id` is part of
+    ///   `Self::Mask`
+    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type<'_>;
+
+    /// If this `LendJoin` typically returns all indices in the mask, then
+    /// iterating over only it or combined with other joins that are also
+    /// dangerous will cause the `JoinLendIter` to go through all indices which
+    /// is usually not what is wanted and will kill performance.
+    #[inline]
+    fn is_unconstrained() -> bool {
+        false
+    }
+}
+
+/// Type alias to refer to the `<J as LendJoin>::Type<'next>` (except this
+/// doesn't actually exist in this form so the `nougat::Gat!` macro is needed).
+pub type LendJoinType<'next, J> = nougat::Gat!(<J as LendJoin>::Type<'next>);
+
+/// `JoinLendIter` is an is a lending/streaming iterator over components from a
+/// group of storages.
+#[must_use]
+pub struct JoinLendIter<J: LendJoin> {
+    keys: BitIter<J::Mask>,
+    values: J::Value,
+}
+
+impl<J: LendJoin> JoinLendIter<J> {
+    /// Create a new lending join iterator.
+    pub fn new(j: J) -> Self {
+        if <J as LendJoin>::is_unconstrained() {
+            log::warn!(
+                "`LendJoin` possibly iterating through all indices, \
+                you might've made a join with all `MaybeJoin`s, \
+                which is unbounded in length."
+            );
+        }
+
+        // SAFETY: We do not swap out the mask or the values, nor do we allow it
+        // by exposing them.
+        let (keys, values) = unsafe { j.open() };
+        JoinLendIter {
+            keys: keys.iter(),
+            values,
+        }
+    }
+}
+
+impl<J: LendJoin> JoinLendIter<J> {
+    /// Lending `next`.
+    ///
+    /// Can be used to iterate with this pattern:
+    ///
+    /// `while let Some(components) = join_lending_iter.next() {`
+    fn next(&mut self) -> Option<LendJoinType<'_, J>> {
+        // SAFETY: since `idx` is yielded from `keys` (the mask), it is necessarily a
+        // part of it. Thus, requirements are fulfilled for calling `get`.
+        self.keys
+            .next()
+            .map(|idx| unsafe { J::get(&mut self.values, idx) })
+    }
+
+    fn for_each(mut self, mut f: impl FnMut(LendJoinType<'_, J>)) {
+        self.keys.for_each(|idx| {
+            // SAFETY: since `idx` is yielded from `keys` (the mask), it is
+            // necessarily a part of it. Thus, requirements are fulfilled for
+            // calling `get`.
+            let item = unsafe { J::get(&mut self.values, idx) };
+            f(item);
+        })
+    }
+
+    /// Allows getting joined values for specific entity.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// # use specs::prelude::*;
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Pos; impl Component for Pos { type Storage = VecStorage<Self>; }
+    /// # #[derive(Debug, PartialEq)]
+    /// # struct Vel; impl Component for Vel { type Storage = VecStorage<Self>; }
+    /// let mut world = World::new();
+    ///
+    /// world.register::<Pos>();
+    /// world.register::<Vel>();
+    ///
+    /// // This entity could be stashed anywhere (into `Component`, `Resource`, `System`s data, etc.) as it's just a number.
+    /// let entity = world
+    ///     .create_entity()
+    ///     .with(Pos)
+    ///     .with(Vel)
+    ///     .build();
+    ///
+    /// // Later
+    /// {
+    ///     let mut pos = world.write_storage::<Pos>();
+    ///     let vel = world.read_storage::<Vel>();
+    ///
+    ///     assert_eq!(
+    ///         Some((&mut Pos, &Vel)),
+    ///         (&mut pos, &vel).lend_join().get(entity, &world.entities()),
+    ///         "The entity that was stashed still has the needed components and is alive."
+    ///     );
+    /// }
+    ///
+    /// // The entity has found nice spot and doesn't need to move anymore.
+    /// world.write_storage::<Vel>().remove(entity);
+    ///
+    /// // Even later
+    /// {
+    ///     let mut pos = world.write_storage::<Pos>();
+    ///     let vel = world.read_storage::<Vel>();
+    ///
+    ///     assert_eq!(
+    ///         None,
+    ///         (&mut pos, &vel).lend_join().get(entity, &world.entities()),
+    ///         "The entity doesn't have velocity anymore."
+    ///     );
+    /// }
+    /// ```
+    pub fn get(&mut self, entity: Entity, entities: &Entities) -> Option<LendJoinType<'_, J>> {
+        if self.keys.contains(entity.id()) && entities.is_alive(entity) {
+            // SAFETY: the mask (`keys`) is checked as specified in the docs of `get`.
+            Some(unsafe { J::get(&mut self.values, entity.id()) })
+        } else {
+            None
+        }
+    }
+
+    /// Allows getting joined values for specific raw index.
+    ///
+    /// The raw index for an `Entity` can be retrieved using `Entity::id`
+    /// method.
+    ///
+    /// As this method operates on raw indices, there is no check to see if the
+    /// entity is still alive, so the caller should ensure it instead.
+    pub fn get_unchecked(&mut self, index: Index) -> Option<LendJoinType<'_, J>> {
+        if self.keys.contains(index) {
+            // SAFETY: the mask (`keys`) is checked as specified in the docs of `get`.
+            Some(unsafe { J::get(&mut self.values, index) })
+        } else {
+            None
+        }
+    }
+}

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -1,0 +1,121 @@
+use super::{Join, LendJoin, ParJoin};
+
+/// Returns a structure that implements `Join`/`LendJoin`/`MaybeJoin` if the
+/// contained `T` does and that yields all indices, returning `None` for all
+/// missing elements and `Some(T)` for found elements.
+///
+/// For usage see [`LendJoin::maybe()`](LendJoin::Maybe).
+///
+/// WARNING: Do not have a join of only `MaybeJoin`s. Otherwise the join will
+/// iterate over every single index of the bitset. If you want a join with
+/// all `MaybeJoin`s, add an `EntitiesRes` to the join as well to bound the
+/// join to all entities that are alive.
+pub struct MaybeJoin(pub J);
+
+// SAFETY: We return a mask containing all items, but check the original mask in
+// the `get` implementation.
+unsafe impl LendJoin for MaybeJoin<T>
+where
+    T: LendJoin,
+{
+    type Mask = BitSetAll;
+    type Type = Option<<T as LendJoin>::Type>;
+    type Value = (<T as LendJoin>::Mask, <T as LendJoin>::Value);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        // SAFETY: While we do expose the mask and the values and therefore
+        // would allow swapping them, this method is `unsafe` and relies on the
+        // same invariants.
+        let (mask, value) = unsafe { self.0.open() };
+        (BitSetAll, (mask, value))
+    }
+
+    unsafe fn get((mask, value): &mut Self::Value, id: Index) -> Self::Type {
+        if mask.contains(id) {
+            // SAFETY: The mask was just checked for `id`.
+            Some(unsafe { <T as LendJoin>::get(value, id) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn is_unconstrained() -> bool {
+        true
+    }
+}
+
+// SAFETY: We return a mask containing all items, but check the original mask in
+// the `get` implementation.
+unsafe impl<T> Join for MaybeJoin<T>
+where
+    T: Join,
+{
+    type Mask = BitSetAll;
+    type Type = Option<<T as Join>::Type>;
+    type Value = (<T as Join>::Mask, <T as Join>::Value);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        // SAFETY: While we do expose the mask and the values and therefore
+        // would allow swapping them, this method is `unsafe` and relies on the
+        // same invariants.
+        let (mask, value) = unsafe { self.0.open() };
+        (BitSetAll, (mask, value))
+    }
+
+    unsafe fn get((mask, value): &mut Self::Value, id: Index) -> Self::Type {
+        if mask.contains(id) {
+            // SAFETY: The mask was just checked for `id`. This has the same
+            // requirements on the caller to not call with the same `id` until
+            // the previous value is no longer in use.
+            Some(unsafe { <T as Join>::get(value, id) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn is_unconstrained() -> bool {
+        true
+    }
+}
+
+// SAFETY: This is safe as long as `T` implements `ParJoin` safely. The `get`
+// implementation here makes no assumptions about being called from a single
+// thread.
+//
+// We return a mask containing all items, but check the original mask in
+// the `get` implementation.
+#[cfg(feature = "parallel")]
+unsafe impl<T> ParJoin for MaybeJoin<T>
+where
+    T: ParJoin,
+{
+    type Mask = BitSetAll;
+    type Type = Option<<T as ParJoin>::Type>;
+    type Value = (<T as ParJoin>::Mask, <T as ParJoin>::Value);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        // SAFETY: While we do expose the mask and the values and therefore
+        // would allow swapping them, this method is `unsafe` and relies on the
+        // same invariants.
+        let (mask, value) = unsafe { self.0.open() };
+        (BitSetAll, (mask, value))
+    }
+
+    unsafe fn get((mask, value): &Self::Value, id: Index) -> Self::Type {
+        if mask.contains(id) {
+            // SAFETY: The mask was just checked for `id`. This has the same
+            // requirements on the caller to not call with the same `id` until
+            // the previous value is no longer in use.
+            Some(unsafe { <T as ParJoin>::get(value, id) })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn is_unconstrained() -> bool {
+        true
+    }
+}

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -38,10 +38,7 @@ where
         (BitSetAll, (mask, value))
     }
 
-    unsafe fn get<'next>((mask, value): &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>((mask, value): &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         if mask.contains(id) {
             // SAFETY: The mask was just checked for `id`. Requirement to not
             // call with the same ID more than once (unless `RepeatableLendGet`

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -81,8 +81,7 @@ where
     unsafe fn get((mask, value): &mut Self::Value, id: Index) -> Self::Type {
         if mask.contains(id) {
             // SAFETY: The mask was just checked for `id`. This has the same
-            // requirements on the caller to not call with the same `id` until
-            // the previous value is no longer in use.
+            // requirements on the caller to only call with the same `id` once.
             Some(unsafe { <T as Join>::get(value, id) })
         } else {
             None
@@ -100,7 +99,7 @@ where
 // thread.
 //
 // We return a mask containing all items, but check the original mask in
-// the `get` implementation.
+// the `get` implementation. Iterating the mask does not repeat indices.
 #[cfg(feature = "parallel")]
 unsafe impl<T> ParJoin for MaybeJoin<T>
 where

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -36,7 +36,10 @@ where
         (BitSetAll, (mask, value))
     }
 
-    unsafe fn get((mask, value): &mut Self::Value, id: Index) -> Self::Type<'_> {
+    unsafe fn get<'next>((mask, value): &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
         if mask.contains(id) {
             // SAFETY: The mask was just checked for `id`.
             Some(unsafe { <T as LendJoin>::get(value, id) })

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -61,7 +61,7 @@ where
 unsafe impl<T> RepeatableLendGet for MaybeJoin<T> where T: RepeatableLendGet {}
 
 // SAFETY: We return a mask containing all items, but check the original mask in
-// the `get` implementation.
+// the `get` implementation. Iterating the mask does not repeat indices.
 unsafe impl<T> Join for MaybeJoin<T>
 where
     T: Join,

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -9,7 +9,7 @@ use crate::world::Index;
 /// contained `T` does and that yields all indices, returning `None` for all
 /// missing elements and `Some(T)` for found elements.
 ///
-/// For usage see [`LendJoin::maybe()`](LendJoin::Maybe).
+/// For usage see [`LendJoin::maybe()`](LendJoin::maybe).
 ///
 /// WARNING: Do not have a join of only `MaybeJoin`s. Otherwise the join will
 /// iterate over every single index of the bitset. If you want a join with

--- a/src/join/maybe.rs
+++ b/src/join/maybe.rs
@@ -1,6 +1,8 @@
 #[nougat::gat(Type)]
 use super::LendJoin;
-use super::{Join, ParJoin, RepeatableLendGet};
+#[cfg(feature = "parallel")]
+use super::ParJoin;
+use super::{Join, RepeatableLendGet};
 use hibitset::{BitSetAll, BitSetLike};
 
 use crate::world::Index;

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -95,9 +95,8 @@ pub use par_join::{JoinParIter, ParJoin};
 /// The `Self::Mask` value returned with the `Self::Value` must correspond such
 /// that it is safe to retrieve items from `Self::Value` whose presence is
 /// indicated in the mask. As part of this, `BitSetLike::iter` must not produce
-/// an iterator that repeats an `Index` value if the `LendJoin::get` impl relies
-/// on not being called twice with the same `Index`. (S-TODO update impls:
-/// probably restrict, entry, and drain)
+/// an iterator that repeats an `Index` value. (S-TODO update impls: probably
+/// drain)
 pub unsafe trait Join {
     /// Type of joined components.
     type Type;

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -218,8 +218,7 @@ macro_rules! define_open {
 
             #[allow(non_snake_case)]
             unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
-            where
-                Self: 'next,
+
             {
                 let &mut ($(ref mut $from,)*) = v;
                 // SAFETY: `get` is safe to call as the caller must have checked
@@ -389,8 +388,7 @@ macro_rules! immutable_resource_join {
             }
 
             unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
-            where
-                Self: 'next,
+
             {
                 // SAFETY: The mask of `Self` and `T` are identical, thus a
                 // check to `Self`'s mask (which is required) is equal to a
@@ -509,8 +507,7 @@ macro_rules! mutable_resource_join {
             }
 
             unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
-            where
-                Self: 'next,
+
             {
                 // SAFETY: The mask of `Self` and `T` are identical, thus a
                 // check to `Self`'s mask (which is required) is equal to a

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -95,8 +95,7 @@ pub use par_join::{JoinParIter, ParJoin};
 /// The `Self::Mask` value returned with the `Self::Value` must correspond such
 /// that it is safe to retrieve items from `Self::Value` whose presence is
 /// indicated in the mask. As part of this, `BitSetLike::iter` must not produce
-/// an iterator that repeats an `Index` value. (S-TODO update impls: probably
-/// drain)
+/// an iterator that repeats an `Index` value.
 pub unsafe trait Join {
     /// Type of joined components.
     type Type;
@@ -125,7 +124,6 @@ pub unsafe trait Join {
 
     /// Get a joined component value by a given index.
     ///
-    // S-TODO: evaluate all impls (TODO: probably restrict, entry, and drain)
     ///
     /// # Safety
     ///

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -215,7 +215,10 @@ macro_rules! define_open {
             }
 
             #[allow(non_snake_case)]
-            unsafe fn get(v: &mut Self::Value, i: Index) -> Self::Type<'_> {
+            unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
+            where
+                Self: 'next,
+            {
                 let &mut ($(ref mut $from,)*) = v;
                 // SAFETY: `get` is safe to call as the caller must have checked
                 // the mask, which only has a key that exists in all of the
@@ -369,7 +372,10 @@ macro_rules! immutable_resource_join {
                 unsafe { self.deref().open() }
             }
 
-            unsafe fn get(v: &mut Self::Value, i: Index) -> Self::Type<'_> {
+            unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
+            where
+                Self: 'next,
+            {
                 // SAFETY: The mask of `Self` and `T` are identical, thus a
                 // check to `Self`'s mask (which is required) is equal to a
                 // check of `T`'s mask, which makes `get` safe to call.
@@ -470,7 +476,10 @@ macro_rules! mutable_resource_join {
                 unsafe { self.deref_mut().open() }
             }
 
-            unsafe fn get(v: &mut Self::Value, i: Index) -> Self::Type<'_> {
+            unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> Self::Type<'next>
+            where
+                Self: 'next,
+            {
                 // SAFETY: The mask of `Self` and `T` are identical, thus a check to
                 // `Self`'s mask (which is required) is equal to a check of `T`'s
                 // mask, which makes `get_mut` safe to call.

--- a/src/join/mod.rs
+++ b/src/join/mod.rs
@@ -96,7 +96,8 @@ pub use par_join::{JoinParIter, ParJoin};
 /// that it is safe to retrieve items from `Self::Value` whose presence is
 /// indicated in the mask. As part of this, `BitSetLike::iter` must not produce
 /// an iterator that repeats an `Index` value if the `LendJoin::get` impl relies
-/// on not being called twice with the same `Index`. (S-TODO update impls)
+/// on not being called twice with the same `Index`. (S-TODO update impls:
+/// probably restrict, entry, and drain)
 pub unsafe trait Join {
     /// Type of joined components.
     type Type;

--- a/src/join/par_join.rs
+++ b/src/join/par_join.rs
@@ -17,7 +17,7 @@ use crate::world::Index;
 /// The `Self::Mask` value returned with the `Self::Value` must correspond such
 /// that it is safe to retrieve items from `Self::Value` whose presence is
 /// indicated in the mask. As part of this, `BitSetLike::iter` must not produce
-/// an iterator that repeats an `Index` value. (S-TODO update impls)
+/// an iterator that repeats an `Index` value.
 pub unsafe trait ParJoin {
     /// Type of joined components.
     type Type;
@@ -58,8 +58,8 @@ pub unsafe trait ParJoin {
     ///
     /// * A call to `get` must be preceded by a check if `id` is part of
     ///   `Self::Mask`.
-    /// * The value returned from this method must be dropped before subsequent
-    ///   calls with the same `id`. (S-TODO update callers to match edit)
+    /// * The value returned from this method must no longer be alive before
+    ///   subsequent calls with the same `id`.
     unsafe fn get(value: &Self::Value, id: Index) -> Self::Type;
 
     /// If this `LendJoin` typically returns all indices in the mask, then

--- a/src/join/par_join.rs
+++ b/src/join/par_join.rs
@@ -14,9 +14,10 @@ use crate::world::Index;
 ///
 /// `ParJoin::get` must be callable from multiple threads, simultaneously.
 ///
-/// The Self::Mask` value returned with the `Self::Value` must correspond such
+/// The `Self::Mask` value returned with the `Self::Value` must correspond such
 /// that it is safe to retrieve items from `Self::Value` whose presence is
-/// indicated in the mask.
+/// indicated in the mask. As part of this, `BitSetLike::iter` must not produce
+/// an iterator that repeats an `Index` value. (S-TODO update impls)
 pub unsafe trait ParJoin {
     /// Type of joined components.
     type Type;
@@ -146,7 +147,8 @@ where
         let JoinProducer { values, keys, .. } = self;
         // SAFETY: `idx` is obtained from the `Mask` returned by
         // `ParJoin::open`. The indices here are guaranteed to be distinct
-        // because of the fact that the bit set is split.
+        // because of the fact that the bit set is split and because `ParJoin`
+        // requires that the bit set iterator doesn't repeat indices.
         let iter = keys.0.map(|idx| unsafe { J::get(values, idx) });
 
         folder.consume_iter(iter)

--- a/src/join/par_join.rs
+++ b/src/join/par_join.rs
@@ -15,34 +15,74 @@ use rayon::iter::{
 /// # Safety
 ///
 /// The implementation of `ParallelIterator` for `ParJoin` makes multiple
-/// assumptions on the structure of `Self`. In particular, `<Self as Join>::get`
-/// must be callable from multiple threads, simultaneously, without mutating
-/// values not exclusively associated with `id`.
-// NOTE: This is currently unspecified behavior. It seems very unlikely that it
-// breaks in the future, but technically it's not specified as valid Rust code.
-pub unsafe trait ParJoin: Join {
+/// assumptions on the structure of `Self`. In particular, `ParJoin::get` must
+/// be callable from multiple threads, simultaneously, without creating mutable
+/// references not exclusively associated with `id`.
+///
+/// The `Self::Mask` value returned with the `Self::Value` must correspond such
+/// that it is safe to retrieve items from `Self::Value` whose presence is
+/// indicated in the mask.
+pub unsafe trait ParJoin {
+    /// Type of joined components.
+    type Type;
+    /// Type of joined storages.
+    type Value;
+    /// Type of joined bit mask.
+    type Mask: BitSetLike;
+
     /// Create a joined parallel iterator over the contents.
     fn par_join(self) -> JoinParIter<Self>
     where
         Self: Sized,
     {
-        if <Self as Join>::is_unconstrained() {
+        if Self::is_unconstrained() {
             log::warn!(
-                "`ParJoin` possibly iterating through all indices, you might've made a join with all `MaybeJoin`s, which is unbounded in length."
+                "`ParJoin` possibly iterating through all indices, \
+                you might've made a join with all `MaybeJoin`s, \
+                which is unbounded in length."
             );
         }
 
         JoinParIter(self)
     }
+
+    /// Open this join by returning the mask and the storages.
+    ///
+    /// # Safety
+    ///
+    /// This is unsafe because implementations of this trait can permit the
+    /// `Value` to be mutated independently of the `Mask`. If the `Mask` does
+    /// not correctly report the status of the `Value` then illegal memory
+    /// access can occur.
+    unsafe fn open(self) -> (Self::Mask, Self::Value);
+
+    /// Get a joined component value by a given index.
+    ///
+    /// # Safety
+    ///
+    /// * A call to `get` must be preceded by a check if `id` is part of
+    ///   `Self::Mask`.
+    /// * The use of the mutable reference returned from this method must end
+    ///   before subsequent calls with the same `id`.
+    unsafe fn get(value: &Self::Value, id: Index) -> Self::Type;
+
+    /// If this `LendJoin` typically returns all indices in the mask, then
+    /// iterating over only it or combined with other joins that are also
+    /// dangerous will cause the `JoinLendIter` to go through all indices which
+    /// is usually not what is wanted and will kill performance.
+    #[inline]
+    fn is_unconstrained() -> bool {
+        false
+    }
 }
 
-/// `JoinParIter` is a `ParallelIterator` over a group of `Storages`.
+/// `JoinParIter` is a `ParallelIterator` over a group of storages.
 #[must_use]
 pub struct JoinParIter<J>(J);
 
 impl<J> ParallelIterator for JoinParIter<J>
 where
-    J: Join + Send,
+    J: ParJoin + Send,
     J::Mask: Send + Sync,
     J::Type: Send,
     J::Value: Send,
@@ -53,12 +93,11 @@ where
     where
         C: UnindexedConsumer<Self::Item>,
     {
+        // SAFETY: `keys` and `values` are not exposed outside this module and
+        // we only use `values` for calling `ParJoin::get`.
         let (keys, values) = unsafe { self.0.open() };
         // Create a bit producer which splits on up to three levels
         let producer = BitProducer((&keys).iter(), 3);
-        // HACK: use `UnsafeCell` to share `values` between threads;
-        // this is the unspecified behavior referred to above.
-        let values = UnsafeCell::new(values);
 
         bridge_unindexed(JoinProducer::<J>::new(producer, &values), consumer)
     }
@@ -66,47 +105,30 @@ where
 
 struct JoinProducer<'a, J>
 where
-    J: Join + Send,
+    J: ParJoin + Send,
     J::Mask: Send + Sync + 'a,
     J::Type: Send,
     J::Value: Send + 'a,
 {
     keys: BitProducer<'a, J::Mask>,
-    values: &'a UnsafeCell<J::Value>,
+    values: &'a J::Value,
 }
 
 impl<'a, J> JoinProducer<'a, J>
 where
-    J: Join + Send,
+    J: ParJoin + Send,
     J::Type: Send,
     J::Value: 'a + Send,
     J::Mask: 'a + Send + Sync,
 {
-    fn new(keys: BitProducer<'a, J::Mask>, values: &'a UnsafeCell<J::Value>) -> Self {
+    fn new(keys: BitProducer<'a, J::Mask>, values: &'a J::Value) -> Self {
         JoinProducer { keys, values }
     }
 }
 
-// SAFETY: `Send` is safe to implement if all components of `Self` are logically
-// `Send`. `keys` already has `Send` implemented, thus no reasoning is required.
-// `values` is a reference to an `UnsafeCell` wrapping `J::Value`;
-// `J::Value` is constrained to implement `Send`.
-// `UnsafeCell` provides interior mutability, but the specification of it allows
-// sharing as long as access does not happen simultaneously; this makes it
-// generally safe to `Send`, but we are accessing it simultaneously, which is
-// technically not allowed. Also see https://github.com/slide-rs/specs/issues/220
-unsafe impl<'a, J> Send for JoinProducer<'a, J>
-where
-    J: Join + Send,
-    J::Type: Send,
-    J::Value: 'a + Send,
-    J::Mask: 'a + Send + Sync,
-{
-}
-
 impl<'a, J> UnindexedProducer for JoinProducer<'a, J>
 where
-    J: Join + Send,
+    J: ParJoin + Send,
     J::Type: Send,
     J::Value: 'a + Send,
     J::Mask: 'a + Send + Sync,
@@ -127,14 +149,10 @@ where
         F: Folder<Self::Item>,
     {
         let JoinProducer { values, keys, .. } = self;
-        let iter = keys.0.map(|idx| unsafe {
-            // This unsafe block should be safe if the `J::get`
-            // can be safely called from different threads with distinct indices.
-
-            // The indices here are guaranteed to be distinct because of the fact
-            // that the bit set is split.
-            J::get(&mut *values.get(), idx)
-        });
+        // SAFETY: `idx` is obtained from the `Mask` returned by
+        // `ParJoin::open`. The indices here are guaranteed to be distinct
+        // because of the fact that the bit set is split.
+        let iter = keys.0.map(|idx| unsafe { J::get(values, idx) });
 
         folder.consume_iter(iter)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub use specs_derive::{Component, ConvertSaveload};
 pub use crate::join::ParJoin;
 pub use crate::{
     changeset::ChangeSet,
-    join::Join,
+    join::{Join, LendJoin},
     storage::{
         DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage,
         ReadStorage, Storage, Tracked, VecStorage, WriteStorage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub extern crate uuid;
 pub mod saveload;
 
 mod bitset;
-// D-TODO pub mod changeset;
+pub mod changeset;
 pub mod error;
 pub mod join;
 pub mod prelude;
@@ -227,7 +227,7 @@ pub use specs_derive::{Component, ConvertSaveload};
 #[cfg(feature = "parallel")]
 pub use crate::join::ParJoin;
 pub use crate::{
-    // D-TODO changeset::ChangeSet,
+    changeset::ChangeSet,
     join::{Join, LendJoin},
     storage::{
         DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,6 @@
 #![warn(missing_docs)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::disallowed_types)]
-#![cfg_attr(
-    feature = "nightly",
-    feature(generic_associated_types, associated_type_defaults)
-)]
 
 //! # SPECS Parallel ECS
 //!
@@ -236,5 +232,4 @@ pub use crate::{
     world::{Builder, Component, Entities, Entity, EntityBuilder, LazyUpdate, WorldExt},
 };
 
-#[cfg(feature = "nightly")]
 pub use crate::storage::DerefFlaggedStorage;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![deny(clippy::disallowed_types)]
 #![cfg_attr(
     feature = "nightly",
@@ -202,7 +203,7 @@ pub extern crate uuid;
 pub mod saveload;
 
 mod bitset;
-pub mod changeset;
+// D-TODO pub mod changeset;
 pub mod error;
 pub mod join;
 pub mod prelude;
@@ -226,7 +227,7 @@ pub use specs_derive::{Component, ConvertSaveload};
 #[cfg(feature = "parallel")]
 pub use crate::join::ParJoin;
 pub use crate::{
-    changeset::ChangeSet,
+    // D-TODO changeset::ChangeSet,
     join::{Join, LendJoin},
     storage::{
         DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage, NullStorage,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,7 +20,7 @@ pub use rayon::iter::ParallelIterator;
 pub use shred::AsyncDispatcher;
 
 pub use crate::{
-    // D-TODO changeset::ChangeSet,
+    changeset::ChangeSet,
     storage::{
         ComponentEvent, DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage,
         NullStorage, ReadStorage, Storage, Tracked, VecStorage, WriteStorage,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,7 +18,7 @@ pub use rayon::iter::ParallelIterator;
 pub use shred::AsyncDispatcher;
 
 pub use crate::{
-    changeset::ChangeSet,
+    // D-TODO changeset::ChangeSet,
     storage::{
         ComponentEvent, DefaultVecStorage, DenseVecStorage, FlaggedStorage, HashMapStorage,
         NullStorage, ReadStorage, Storage, Tracked, VecStorage, WriteStorage,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,9 +2,9 @@
 //!
 //! Contains all of the most common traits, structures,
 
-pub use crate::join::Join;
 #[cfg(feature = "parallel")]
 pub use crate::join::ParJoin;
+pub use crate::join::{Join, LendJoin};
 pub use hibitset::BitSet;
 pub use shred::{
     Accessor, Dispatcher, DispatcherBuilder, Read, ReadExpect, Resource, ResourceId, RunNow,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,9 +2,11 @@
 //!
 //! Contains all of the most common traits, structures,
 
+pub use crate::join::Join;
+#[nougat::gat(Type)]
+pub use crate::join::LendJoin;
 #[cfg(feature = "parallel")]
 pub use crate::join::ParJoin;
-pub use crate::join::{Join, LendJoin};
 pub use hibitset::BitSet;
 pub use shred::{
     Accessor, Dispatcher, DispatcherBuilder, Read, ReadExpect, Resource, ResourceId, RunNow,

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -348,7 +348,9 @@ pub trait MarkerAllocator<M: Marker>: Resource {
         entity: Entity,
         storage: &'m mut WriteStorage<M>,
     ) -> Option<(&'m M, bool)> {
-        let new = if let Ok(entry) = storage.entry(entity) {
+        todo!()
+        // D-TODO (uncomment when entry API is re-enabled!)
+        /*let new = if let Ok(entry) = storage.entry(entity) {
             let mut new = false;
             let _marker = entry.or_insert_with(|| {
                 new = true;
@@ -359,7 +361,7 @@ pub trait MarkerAllocator<M: Marker>: Resource {
         } else {
             return None;
         };
-        Some((storage.get(entity).unwrap(), new))
+        Some((storage.get(entity).unwrap(), new))*/
     }
 
     /// Maintain internal data. Cleanup if necessary.

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -11,6 +11,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::{
     prelude::*,
+    storage::AccessMut,
     world::{EntitiesRes, EntityResBuilder, LazyBuilder},
 };
 
@@ -324,7 +325,7 @@ pub trait MarkerAllocator<M: Marker>: Resource {
     ) -> Entity {
         if let Some(entity) = self.retrieve_entity_internal(marker.id()) {
             if let Some(mut marker_comp) = storage.get_mut(entity) {
-                marker_comp.update(marker);
+                marker_comp.access_mut().update(marker);
 
                 return entity;
             }

--- a/src/saveload/marker.rs
+++ b/src/saveload/marker.rs
@@ -348,9 +348,7 @@ pub trait MarkerAllocator<M: Marker>: Resource {
         entity: Entity,
         storage: &'m mut WriteStorage<M>,
     ) -> Option<(&'m M, bool)> {
-        todo!()
-        // D-TODO (uncomment when entry API is re-enabled!)
-        /*let new = if let Ok(entry) = storage.entry(entity) {
+        let new = if let Ok(entry) = storage.entry(entity) {
             let mut new = false;
             let _marker = entry.or_insert_with(|| {
                 new = true;
@@ -361,7 +359,7 @@ pub trait MarkerAllocator<M: Marker>: Resource {
         } else {
             return None;
         };
-        Some((storage.get(entity).unwrap(), new))*/
+        Some((storage.get(entity).unwrap(), new))
     }
 
     /// Maintain internal data. Cleanup if necessary.

--- a/src/storage/data.rs
+++ b/src/storage/data.rs
@@ -124,7 +124,7 @@ where
         res.entry::<MaskedStorage<T>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T>>());
+            .register::<MaskedStorage<T>>();
     }
 
     fn fetch(res: &'a World) -> Self {
@@ -211,7 +211,7 @@ where
         res.entry::<MaskedStorage<T>>()
             .or_insert_with(|| MaskedStorage::new(<T::Storage as TryDefault>::unwrap_default()));
         res.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*res.fetch::<MaskedStorage<T>>());
+            .register::<MaskedStorage<T>>();
     }
 
     fn fetch(res: &'a World) -> Self {

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -123,7 +123,8 @@ impl<C, T> Tracked for DerefFlaggedStorage<C, T> {
     }
 }
 
-/// S-TODO document
+/// Wrapper type only emits modificaition events when the component is accessed
+/// via mutably dereferencing. Also see [`DerefFlaggedStorage`] documentation.
 pub struct FlaggedAccessMut<'a, A, C> {
     channel: &'a mut EventChannel<ComponentEvent>,
     emit: bool,

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -63,36 +63,41 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlag
     where
         B: BitSetLike,
     {
-        self.storage.clean(has);
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.storage.clean(has) };
     }
 
     unsafe fn get(&self, id: Index) -> &C {
-        self.storage.get(id)
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.storage.get(id) }
     }
 
-    unsafe fn get_mut(&self, id: Index) -> Self::AccessMut<'_> {
-        let emit = self.emit_event();
+    unsafe fn get_mut(&self, _id: Index) -> Self::AccessMut<'_> {
+        /*let emit = self.emit_event();
         FlaggedAccessMut {
             channel: &mut self.channel,
             emit,
             id,
             access: self.storage.get_mut(id),
             phantom: PhantomData,
-        }
+        }*/
+        todo!("adapt to streaming only")
     }
 
     unsafe fn insert(&mut self, id: Index, comp: C) {
         if self.emit_event() {
             self.channel.single_write(ComponentEvent::Inserted(id));
         }
-        self.storage.insert(id, comp);
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.storage.insert(id, comp) };
     }
 
     unsafe fn remove(&mut self, id: Index) -> C {
         if self.emit_event() {
             self.channel.single_write(ComponentEvent::Removed(id));
         }
-        self.storage.remove(id)
+        // SAFETY: Requirements passed to caller.
+        unsafe { self.storage.remove(id) }
     }
 }
 
@@ -116,6 +121,7 @@ impl<C, T> Tracked for DerefFlaggedStorage<C, T> {
     }
 }
 
+/// S-TODO document
 pub struct FlaggedAccessMut<'a, A, C> {
     channel: &'a mut EventChannel<ComponentEvent>,
     emit: bool,

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -74,16 +74,16 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlag
         unsafe { self.storage.get(id) }
     }
 
-    unsafe fn get_mut(&mut self, _id: Index) -> Self::AccessMut<'_> {
-        /*let emit = self.emit_event();
+    unsafe fn get_mut(&mut self, id: Index) -> Self::AccessMut<'_> {
+        let emit = self.emit_event();
         FlaggedAccessMut {
             channel: &mut self.channel,
             emit,
             id,
-            access: self.storage.get_mut(id),
+            // SAFETY: Requirements passed to caller.
+            access: unsafe { self.storage.get_mut(id) },
             phantom: PhantomData,
-        }*/
-        todo!("adapt to streaming only")
+        }
     }
 
     unsafe fn insert(&mut self, id: Index, comp: C) {

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -72,7 +72,7 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlag
         unsafe { self.storage.get(id) }
     }
 
-    unsafe fn get_mut(&self, _id: Index) -> Self::AccessMut<'_> {
+    unsafe fn get_mut(&mut self, _id: Index) -> Self::AccessMut<'_> {
         /*let emit = self.emit_event();
         FlaggedAccessMut {
             channel: &mut self.channel,

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -6,7 +6,9 @@ use std::{
 use hibitset::BitSetLike;
 
 use crate::{
-    storage::{ComponentEvent, DenseVecStorage, Tracked, TryDefault, UnprotectedStorage},
+    storage::{
+        AccessMut, ComponentEvent, DenseVecStorage, Tracked, TryDefault, UnprotectedStorage,
+    },
     world::{Component, Index},
 };
 
@@ -143,12 +145,12 @@ where
 
 impl<'a, A, C> DerefMut for FlaggedAccessMut<'a, A, C>
 where
-    A: DerefMut<Target = C>,
+    A: AccessMut<Target = C>,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
         if self.emit {
             self.channel.single_write(ComponentEvent::Modified(self.id));
         }
-        self.access.deref_mut()
+        self.access.access_mut()
     }
 }

--- a/src/storage/deref_flagged.rs
+++ b/src/storage/deref_flagged.rs
@@ -56,10 +56,8 @@ where
 }
 
 impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlaggedStorage<C, T> {
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = FlaggedAccessMut<'a, <T as UnprotectedStorage<C>>::AccessMut<'a>, C>;
+    type AccessMut<'a> = FlaggedAccessMut<'a, <T as UnprotectedStorage<C>>::AccessMut<'a>, C>
+        where T: 'a;
 
     unsafe fn clean<B>(&mut self, has: B)
     where
@@ -72,7 +70,7 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for DerefFlag
         self.storage.get(id)
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> Self::AccessMut<'_> {
+    unsafe fn get_mut(&self, id: Index) -> Self::AccessMut<'_> {
         let emit = self.emit_event();
         FlaggedAccessMut {
             channel: &mut self.channel,

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -36,10 +36,7 @@ where
         (mask, self.data)
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> T
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> T {
         value.remove(id).expect("Tried to access same index twice")
     }
 }

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -1,7 +1,9 @@
 use hibitset::BitSet;
 
+#[nougat::gat(Type)]
+use crate::join::LendJoin;
 use crate::{
-    join::Join,
+    join::{Join, RepeatableLendGet},
     storage::MaskedStorage,
     world::{Component, Index},
 };
@@ -13,18 +15,17 @@ pub struct Drain<'a, T: Component> {
     pub data: &'a mut MaskedStorage<T>,
 }
 
-// S-TODO implement LendJoin
-// S-TODO implement RepeatableLendGet
-
-impl<'a, T> Join for Drain<'a, T>
+// SAFETY: Calling `get` is always safe! Iterating the mask does not repeat
+// indices.
+#[nougat::gat]
+unsafe impl<'a, T> LendJoin for Drain<'a, T>
 where
     T: Component,
 {
     type Mask = BitSet;
-    type Type = T;
+    type Type<'next> = T;
     type Value = &'a mut MaskedStorage<T>;
 
-    // SAFETY: No invariants to meet and no unsafe code.
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
         // TODO: Cloning the whole bitset here seems expensive, and it is
         // hidden from the user, but there is no obvious way to restructure
@@ -35,7 +36,37 @@ where
         (mask, self.data)
     }
 
-    // SAFETY: No invariants to meet and no unsafe code.
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> T
+    where
+        Self: 'next,
+    {
+        value.remove(id).expect("Tried to access same index twice")
+    }
+}
+
+// SAFETY: Calling `get` is always safe!
+unsafe impl<'a, T> RepeatableLendGet for Drain<'a, T> where T: Component {}
+
+// SAFETY: Calling `get` is always safe! Iterating the mask does not repeat
+// indices.
+unsafe impl<'a, T> Join for Drain<'a, T>
+where
+    T: Component,
+{
+    type Mask = BitSet;
+    type Type = T;
+    type Value = &'a mut MaskedStorage<T>;
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        // TODO: Cloning the whole bitset here seems expensive, and it is
+        // hidden from the user, but there is no obvious way to restructure
+        // things to avoid this with the way that bitsets are composed together
+        // for iteration.
+        let mask = self.data.mask.clone();
+
+        (mask, self.data)
+    }
+
     unsafe fn get(value: &mut Self::Value, id: Index) -> T {
         value.remove(id).expect("Tried to access same index twice")
     }

--- a/src/storage/drain.rs
+++ b/src/storage/drain.rs
@@ -13,6 +13,9 @@ pub struct Drain<'a, T: Component> {
     pub data: &'a mut MaskedStorage<T>,
 }
 
+// S-TODO implement LendJoin
+// S-TODO implement RepeatableLendGet
+
 impl<'a, T> Join for Drain<'a, T>
 where
     T: Component,
@@ -23,6 +26,10 @@ where
 
     // SAFETY: No invariants to meet and no unsafe code.
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        // TODO: Cloning the whole bitset here seems expensive, and it is
+        // hidden from the user, but there is no obvious way to restructure
+        // things to avoid this with the way that bitsets are composed together
+        // for iteration.
         let mask = self.data.mask.clone();
 
         (mask, self.data)

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -151,10 +151,7 @@ where
         (BitSetAll, self.0)
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         value.entry_inner(id)
     }
 

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -147,15 +147,18 @@ where
         // This is HACK. See implementation of Join for &'a mut Storage<'e, T, D> for
         // details why it is necessary.
         let storage: *mut Storage<'b, T, D> = *value as *mut Storage<'b, T, D>;
-        if (*storage).data.mask.contains(id) {
+        // SAFETY: S-TODO redo when updating join trait
+        if unsafe { &*storage }.data.mask.contains(id) {
             StorageEntry::Occupied(OccupiedEntry {
                 id,
-                storage: &mut *storage,
+                // SAFETY: S-TODO redo when updating join trait
+                storage: unsafe { &mut *storage },
             })
         } else {
             StorageEntry::Vacant(VacantEntry {
                 id,
-                storage: &mut *storage,
+                // SAFETY: S-TODO redo when updating join trait
+                storage: unsafe { &mut *storage },
             })
         }
     }
@@ -192,6 +195,7 @@ where
 {
     /// Get a mutable reference to the component associated with the entity.
     pub fn get_mut(&mut self) -> AccessMutReturn<'_, T> {
+        // S-TODO update safety comment after changing Join
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -200,6 +204,7 @@ where
     /// Converts the `OccupiedEntry` into a mutable reference bounded by
     /// the storage's lifetime.
     pub fn into_mut(self) -> AccessMutReturn<'a, T> {
+        // S-TODO update safety comment after changing Join
         // SAFETY: This is safe since `OccupiedEntry` is only constructed
         // after checking the mask.
         unsafe { self.storage.data.inner.get_mut(self.id) }
@@ -231,10 +236,11 @@ where
 {
     /// Inserts a value into the storage.
     pub fn insert(self, component: T) -> AccessMutReturn<'a, T> {
-        self.storage.data.mask.add(self.id);
+        // S-TODO safety comment incomplete
         // SAFETY: This is safe since we added `self.id` to the mask.
         unsafe {
             self.storage.data.inner.insert(self.id, component);
+            self.storage.data.mask.add(self.id);
             self.storage.data.inner.get_mut(self.id)
         }
     }

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -54,8 +54,8 @@ where
         }
     }
 
-    /// Returns a `Join`-able structure that yields all indices, returning
-    /// `Entry` for all elements
+    /// Returns a [`LendJoin`]-able structure that yields all indices, returning
+    /// [`StorageEntry`] for all elements
     ///
     /// WARNING: Do not have a join of only `Entries`s. Otherwise the join will
     /// iterate over every single index of the bitset. If you want a join with
@@ -129,8 +129,10 @@ where
     }
 }
 
-/// `Join`-able structure that yields all indices, returning `Entry` for all
-/// elements.
+/// [`LendJoin`]-able structure that yields all indices,
+/// returning [`StorageEntry`] for all elements.
+///
+/// This can be constructed via [`Storage::entries`].
 pub struct Entries<'a, 'b: 'a, T: 'a, D: 'a>(&'a mut Storage<'b, T, D>);
 
 // SAFETY: We return a mask containing all items, but check the original mask in

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -162,6 +162,15 @@ where
     }
 }
 
+// SAFETY: LendJoin::get impl for this type is safe to call multiple times with
+// the same ID.
+unsafe impl<'a, 'b: 'a, T: 'a, D: 'a> RepeatableLendGet for Entries<'a, 'b, T, D>
+where
+    T: Component,
+    D: DerefMut<Target = MaskedStorage<T>>,
+{
+}
+
 /// An entry to a storage which has a component associated to the entity.
 pub struct OccupiedEntry<'a, 'b: 'a, T: 'a, D: 'a> {
     id: Index,

--- a/src/storage/entry.rs
+++ b/src/storage/entry.rs
@@ -101,7 +101,7 @@ where
     /// # }
     /// #
     /// # world.exec(|(mut counters, marker): (WriteStorage<Counter>, ReadStorage<AllowCounter>)| {
-    /// let mut join = (counter.entries(), &marker).lend_join();
+    /// let mut join = (counters.entries(), &marker).lend_join();
     /// while let Some((mut counter, _)) = join.next() {
     ///     let counter = counter.or_insert_with(Default::default);
     ///     counter.increase();

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -203,10 +203,7 @@ where
 
 impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedStorage<C, T> {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = <T as UnprotectedStorage<C>>::AccessMut<'a>;
+    type AccessMut<'a> = <T as UnprotectedStorage<C>>::AccessMut<'a> where T: 'a;
 
     unsafe fn clean<B>(&mut self, has: B)
     where

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -20,7 +20,7 @@ use shrev::EventChannel;
 ///
 /// What you want to instead is to use `restrict_mut()` to first
 /// get the entities which contain the component and then conditionally
-/// modify the component after a call to `get_mut_unchecked()` or `get_mut()`.
+/// modify the component after a call to `get_mut()` or `get_other_mut()`.
 ///
 /// # Examples
 ///
@@ -102,7 +102,7 @@ use shrev::EventChannel;
 /// #        let condition = true;
 ///         for (entity, mut comps) in (&entities, &mut comps.restrict_mut()).join() {
 ///             if condition { // check whether this component should be modified.
-///                  let mut comp = comps.get_mut_unchecked();
+///                  let mut comp = comps.get_mut();
 ///                  // ...
 ///             }
 ///         }

--- a/src/storage/flagged.rs
+++ b/src/storage/flagged.rs
@@ -1,6 +1,3 @@
-// TODO: promote to the whole crate
-#![deny(unsafe_op_in_unsafe_fn)]
-
 use std::marker::PhantomData;
 
 use hibitset::BitSetLike;
@@ -221,7 +218,7 @@ impl<C: Component, T: UnprotectedStorage<C>> UnprotectedStorage<C> for FlaggedSt
 
     unsafe fn get(&self, id: Index) -> &C {
         // SAFETY: Requirements passed to caller.
-        unsafe { self.storage.get_mut(id) }
+        unsafe { self.storage.get(id) }
     }
 
     #[cfg(feature = "nightly")]

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -88,7 +88,7 @@ pub trait GenericWriteStorage {
     type Component: Component;
     /// The wrapper through with mutable access of a component is performed.
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>: DerefMut<Target = Self::Component>
+    type AccessMut<'a>
     where
         Self: 'a;
 

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "nightly")]
 use crate::storage::{AccessMut, UnprotectedStorage};
 use crate::{
     storage::{AccessMutReturn, InsertResult, ReadStorage, WriteStorage},
@@ -85,7 +84,6 @@ pub trait GenericWriteStorage {
     /// The component type of the storage
     type Component: Component;
     /// The wrapper through with mutable access of a component is performed.
-    #[cfg(feature = "nightly")]
     type AccessMut<'a>: AccessMut<Target = Self::Component>
     where
         Self: 'a;
@@ -118,7 +116,6 @@ impl<'a, T> GenericWriteStorage for WriteStorage<'a, T>
 where
     T: Component,
 {
-    #[cfg(feature = "nightly")]
     type AccessMut<'b> = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'b>
         where Self: 'b;
     type Component = T;
@@ -157,7 +154,6 @@ impl<'a: 'b, 'b, T> GenericWriteStorage for &'b mut WriteStorage<'a, T>
 where
     T: Component,
 {
-    #[cfg(feature = "nightly")]
     type AccessMut<'c> = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'c>
         where Self: 'c;
     type Component = T;

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -121,10 +121,8 @@ where
     T: Component,
 {
     #[cfg(feature = "nightly")]
-    type AccessMut<'b>
-    where
-        Self: 'b,
-    = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'b>;
+    type AccessMut<'b> = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'b>
+        where Self: 'b;
     type Component = T;
 
     fn get_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, T>> {
@@ -162,10 +160,8 @@ where
     T: Component,
 {
     #[cfg(feature = "nightly")]
-    type AccessMut<'c>
-    where
-        Self: 'c,
-    = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'c>;
+    type AccessMut<'c> = <<T as Component>::Storage as UnprotectedStorage<T>>::AccessMut<'c>
+        where Self: 'c;
     type Component = T;
 
     fn get_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, T>> {

--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -1,11 +1,9 @@
 #[cfg(feature = "nightly")]
-use crate::storage::UnprotectedStorage;
+use crate::storage::{AccessMut, UnprotectedStorage};
 use crate::{
     storage::{AccessMutReturn, InsertResult, ReadStorage, WriteStorage},
     world::{Component, Entity},
 };
-#[cfg(feature = "nightly")]
-use std::ops::DerefMut;
 
 pub struct Seal;
 
@@ -88,7 +86,7 @@ pub trait GenericWriteStorage {
     type Component: Component;
     /// The wrapper through with mutable access of a component is performed.
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
+    type AccessMut<'a>: AccessMut<Target = Self::Component>
     where
         Self: 'a;
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -70,11 +70,7 @@ unsafe impl<'a> LendJoin for AntiStorage<'a> {
         (BitSetNot(self.0), ())
     }
 
-    unsafe fn get<'next>(_: &'next mut (), _: Index)
-    where
-        Self: 'next,
-    {
-    }
+    unsafe fn get<'next>(_: &'next mut (), _: Index) {}
 }
 
 // SAFETY: <AntiStorage as LendJoin>::get does nothing.
@@ -492,10 +488,7 @@ where
         (&self.data.mask, &self.data.inner)
     }
 
-    unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> &'a T
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> &'a T {
         // SAFETY: Since we require that the mask was checked, an element for
         // `i` must have been inserted without being removed.
         unsafe { v.get(i) }
@@ -579,10 +572,7 @@ where
         self.data.open_mut()
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // SAFETY: Since we require that the mask was checked, an element for
         // `id` must have been inserted without being removed.
         unsafe { value.get_mut(id) }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -76,7 +76,11 @@ unsafe impl<'a> LendJoin for AntiStorage<'a> {
         (BitSetNot(self.0), ())
     }
 
-    unsafe fn get(_: &mut (), _: Index) {}
+    unsafe fn get<'next>(_: &'next mut (), _: Index)
+    where
+        Self: 'next,
+    {
+    }
 }
 
 // SAFETY: Items are just `()` and it is always safe to retrieve them regardless
@@ -458,7 +462,10 @@ where
         (&self.data.mask, &self.data.inner)
     }
 
-    unsafe fn get(v: &mut Self::Value, i: Index) -> &'a T {
+    unsafe fn get<'next>(v: &'next mut Self::Value, i: Index) -> &'a T
+    where
+        Self: 'next,
+    {
         // SAFETY: Since we require that the mask was checked, an element for
         // `i` must have been inserted without being removed.
         unsafe { v.get(i) }
@@ -532,7 +539,10 @@ where
         self.data.open_mut()
     }
 
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type<'_> {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
         // SAFETY: Since we require that the mask was checked, an element for
         // `id` must have been inserted without being removed.
         unsafe { value.get_mut(id) }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -141,6 +141,8 @@ where
 
 /// This is a marker trait which requires you to uphold the following guarantee:
 ///
+/// # Safety
+///
 /// > Multiple threads may call `SharedGetMutStorage::shared_get_mut()`
 /// with distinct indices without causing > undefined behavior.
 ///

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -486,7 +486,7 @@ where
 
 // SAFETY: The mask and unprotected storage contained in `MaskedStorage`
 // correspond and `open` returns references to them from the same
-// `MaskedStorage` instance.
+// `MaskedStorage` instance. Iterating the mask does not repeat indices.
 unsafe impl<'a, 'e, T, D> Join for &'a Storage<'e, T, D>
 where
     T: Component,
@@ -625,8 +625,8 @@ pub use shared_get_mut_only::SharedGetMutOnly;
 
 // SAFETY: The mask and unprotected storage contained in `MaskedStorage`
 // correspond and `open` returns references to them from the same
-// `MaskedStorage` instance (the storage is wrapped in
-// `SharedGetMutOnly`).
+// `MaskedStorage` instance (the storage is wrapped in `SharedGetMutOnly`).
+// Iterating the mask does not repeat indices.
 unsafe impl<'a, 'e, T, D> Join for &'a mut Storage<'e, T, D>
 where
     T: Component,
@@ -647,9 +647,9 @@ where
         // SAFETY:
         // * Since we require that the mask was checked, an element for
         //   `id` must have been inserted without being removed.
-        // * We also require that the caller drop the value returned before
-        //   subsequent calls with the same `id`, so there are no extant
-        //   references that were obtained with the same `id`.
+        // * We also require that there are no subsequent calls with the same
+        //   `id` for this instance of the values from `open`, so there are no
+        //   extant references for the element corresponding to this `id`.
         // * Since we have an exclusive reference to `Self::Value`, we know this
         //   isn't being called from multiple threads at once.
         unsafe { value.get(id) }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -96,7 +96,8 @@ unsafe impl<'a> Join for AntiStorage<'a> {
 }
 
 // SAFETY: Since `get` does not do anything it is safe to concurrently call.
-// Items are just `()` and it is always safe to retrieve them regardless
+// Items are just `()` and it is always safe to retrieve them regardless of the
+// mask and value returned by `open`.
 #[cfg(feature = "parallel")]
 unsafe impl<'a> ParJoin for AntiStorage<'a> {
     type Mask = BitSetNot<&'a BitSet>;
@@ -539,6 +540,7 @@ where
 //
 // The mask and unprotected storage contained in `MaskedStorage` correspond and
 // `open` returns references to them from the same `MaskedStorage` instance.
+// Iterating the mask does not repeat indices.
 #[cfg(feature = "parallel")]
 unsafe impl<'a, 'e, T, D> ParJoin for &'a Storage<'e, T, D>
 where
@@ -691,7 +693,8 @@ where
 //
 // The mask and unprotected storage contained in `MaskedStorage` correspond and
 // `open` returns references to them from the same `MaskedStorage` instance (the
-// storage is wrapped in `SharedGetMutOnly`).
+// storage is wrapped in `SharedGetMutOnly`). Iterating the mask does not repeat
+// indices.
 #[cfg(feature = "parallel")]
 unsafe impl<'a, 'e, T, D> ParJoin for &'a mut Storage<'e, T, D>
 where
@@ -713,7 +716,7 @@ where
         // SAFETY:
         // * Since we require that the mask was checked, an element for
         //   `id` must have been inserted without being removed.
-        // * We also require that the caller drop the value returned before
+        // * We also require that the returned value is no longer alive before
         //   subsequent calls with the same `id`, so there are no extant
         //   references that were obtained with the same `id`.
         // * `T::Storage` implements the unsafe trait `DistinctStorage` so it is

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -140,8 +140,8 @@ where
 
 /// This is a marker trait which requires you to uphold the following guarantee:
 ///
-/// > Multiple threads may call `shared_get_access_mut()` with distinct indices
-/// without causing > undefined behavior.
+/// > Multiple threads may call `SharedGetAccessMutStorage::shared_get_access_mut()`
+/// with distinct indices without causing > undefined behavior.
 ///
 /// This is for example valid for `Vec`:
 ///
@@ -846,7 +846,7 @@ macro_rules! shared_get_access_mut_docs {
 trait SharedGetAccessMutStorage<T>: UnprotectedStorage<T> {
     #[cfg(feature = "nightly")]
     shared_get_access_mut_docs! {
-        unsafe fn shared_get_access_mut(&self, id: Index) -> <Self as UnprotectedStorage>::AccessMut<'_>;
+        unsafe fn shared_get_access_mut(&self, id: Index) -> <Self as UnprotectedStorage<T>>::AccessMut<'_>;
     }
 
     #[cfg(not(feature = "nightly"))]

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -11,12 +11,11 @@ pub use self::{
         RestrictedStorage, SharedGetOnly,
     },
     storages::{
-        BTreeStorage, DefaultVecStorage, DenseVecStorage, HashMapStorage, NullStorage, VecStorage,
+        BTreeStorage, DefaultVecStorage, DenseVecStorage, HashMapStorage, NullStorage, SliceAccess,
+        VecStorage,
     },
     track::{ComponentEvent, Tracked},
 };
-
-use self::storages::SliceAccess;
 
 use std::{
     self,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -117,15 +117,13 @@ pub trait AnyStorage {
     fn drop(&mut self, entities: &[Entity]);
 }
 
+// SAFETY: Returned pointer has a vtable valid for `T` and retains the same
+// address/provenance.
 unsafe impl<T> CastFrom<T> for dyn AnyStorage
 where
     T: AnyStorage + 'static,
 {
-    fn cast(t: &T) -> &Self {
-        t
-    }
-
-    fn cast_mut(t: &mut T) -> &mut Self {
+    fn cast(t: *mut T) -> *mut Self {
         t
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -37,12 +37,12 @@ use crate::{
     world::{Component, EntitiesRes, Entity, Index},
 };
 
-// D-TODO use self::drain::Drain;
+use self::drain::Drain;
 use self::sync_unsafe_cell::SyncUnsafeCell;
 
 mod data;
 mod deref_flagged;
-// D-TODO mod drain;
+mod drain;
 mod entry;
 mod flagged;
 mod generic;
@@ -449,13 +449,13 @@ where
         self.data.clear();
     }
 
-    // /// Creates a draining storage wrapper which can be `.join`ed
-    // /// to get a draining iterator.
-    // D-TODO pub fn drain(&mut self) -> Drain<T> {
-    //    Drain {
-    //        data: &mut self.data,
-    //    }
-    //}
+    /// Creates a draining storage wrapper which can be `.join`ed
+    /// to get a draining iterator.
+    pub fn drain(&mut self) -> Drain<T> {
+        Drain {
+            data: &mut self.data,
+        }
+    }
 }
 
 impl<'a, T, D: Clone> Clone for Storage<'a, T, D> {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -467,7 +467,6 @@ where
     type Type = AccessMutReturn<'a, T>;
     type Value = &'a mut T::Storage;
 
-    // SAFETY: No unsafe code and no invariants to fulfill.
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
         self.data.open_mut()
     }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -867,6 +867,8 @@ pub trait UnprotectedStorage<T>: TryDefault {
     }
 }
 
+/// Used by the framework to mutably access components in contexts where
+/// exclusive access to the storage is not possible.
 pub trait SharedGetMutStorage<T>: UnprotectedStorage<T> {
     /// Gets mutable access to the the data associated with an `Index`.
     ///

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -676,13 +676,13 @@ where
 
     unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
         // SAFETY:
-        // * Since we require that the mask was checked, an element for
-        //   `id` must have been inserted without being removed.
-        // * We also require that there are no subsequent calls with the same
-        //   `id` for this instance of the values from `open`, so there are no
-        //   extant references for the element corresponding to this `id`.
-        // * Since we have an exclusive reference to `Self::Value`, we know this
-        //   isn't being called from multiple threads at once.
+        // * Since we require that the mask was checked, an element for `id` must have
+        //   been inserted without being removed.
+        // * We also require that there are no subsequent calls with the same `id` for
+        //   this instance of the values from `open`, so there are no extant references
+        //   for the element corresponding to this `id`.
+        // * Since we have an exclusive reference to `Self::Value`, we know this isn't
+        //   being called from multiple threads at once.
         unsafe { SharedGetMutOnly::get_mut(value, id) }
     }
 }
@@ -713,13 +713,13 @@ where
 
     unsafe fn get(value: &Self::Value, id: Index) -> Self::Type {
         // SAFETY:
-        // * Since we require that the mask was checked, an element for
-        //   `id` must have been inserted without being removed.
+        // * Since we require that the mask was checked, an element for `id` must have
+        //   been inserted without being removed.
         // * We also require that the returned value is no longer alive before
-        //   subsequent calls with the same `id`, so there are no extant
-        //   references that were obtained with the same `id`.
-        // * `T::Storage` implements the unsafe trait `DistinctStorage` so it is
-        //   safe to call this from multiple threads at once.
+        //   subsequent calls with the same `id`, so there are no extant references that
+        //   were obtained with the same `id`.
+        // * `T::Storage` implements the unsafe trait `DistinctStorage` so it is safe to
+        //   call this from multiple threads at once.
         unsafe { SharedGetMutOnly::get_mut(value, id) }
     }
 }
@@ -753,7 +753,8 @@ where
 /// Allows forcing mutable access to be explicit. Useful to implement a flagged
 /// storage where it is easier to discover sites where components are marked as
 /// mutated. Of course, individual storages can use an associated `AccessMut`
-/// type that also implements `DerefMut`, but this provides the common denominator.
+/// type that also implements `DerefMut`, but this provides the common
+/// denominator.
 pub trait AccessMut: core::ops::Deref {
     /// This may generate a mutation event for certain flagged storages.
     fn access_mut(&mut self) -> &mut Self::Target;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -410,16 +410,10 @@ where
         // SAFETY: The mask was previously empty, so it is safe to
         // insert. We immediately add the value to the mask below and
         // unwinding from the `insert` call means that we don't need to
-        // include the value in the mask. `BitSet::add` won't unwind on 32-bit
-        // and 64-bit platforms since OOM aborts and any overflow in capacity
-        // calculations (which panics) won't occur for resizing to hold the bit
-        // at `id = u32::MAX`. We rely on `BitSet::add` not having any other
-        // cases where it panics. On 16-bit platforms we insert a guard to abort
-        // if a panic occurs (although I suspect we will run out of memory
-        // before that).
+        // include the value in the mask. If adding to the mask unwinds we
+        // abort.
         unsafe { self.data.inner.insert(id, value) };
-        const _ASSERT_INDEX_IS_U32: Index = 0u32;
-        if cfg!(panic = "abort") || usize::BITS >= 32 {
+        if cfg!(panic = "abort") {
             self.data.mask.add(id);
         } else {
             struct AbortOnDrop;

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -354,6 +354,8 @@ where
 //
 // `open` returns references to corresponding mask and storage values contained
 // in the wrapped `Storage`.
+//
+// Iterating the mask does not repeat indices.
 unsafe impl<'rf, 'st: 'rf, C, S> ParJoin for &'rf RestrictedStorage<'rf, 'st, C, S>
 where
     C: Component,
@@ -388,6 +390,8 @@ where
 //
 // `open` returns references to corresponding mask and storage values contained
 // in the wrapped `Storage`.
+//
+// Iterating the mask does not repeat indices.
 #[cfg(feature = "parallel")]
 unsafe impl<'rf, 'st: 'rf, C, S> ParJoin for &'rf mut RestrictedStorage<'rf, 'st, C, S>
 where

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -112,8 +112,10 @@ where
     type Value = (&'rf C::Storage, &'rf Fetch<'rf, EntitiesRes>, &'rf BitSet);
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow(), self.entities, bitset))
+        (
+            self.bitset,
+            (self.data.borrow(), self.entities, self.bitset),
+        )
     }
 
     unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
@@ -154,8 +156,10 @@ where
     );
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow_mut(), self.entities, bitset))
+        (
+            self.bitset,
+            (self.data.borrow_mut(), self.entities, self.bitset),
+        )
     }
 
     unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
@@ -191,8 +195,10 @@ where
     type Value = (&'rf C::Storage, &'rf Fetch<'rf, EntitiesRes>, &'rf BitSet);
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow(), self.entities, bitset))
+        (
+            self.bitset,
+            (self.data.borrow(), self.entities, self.bitset),
+        )
     }
 
     unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
@@ -362,8 +368,10 @@ where
     type Value = (&'rf C::Storage, &'rf Fetch<'rf, EntitiesRes>, &'rf BitSet);
 
     unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow(), self.entities, bitset))
+        (
+            self.bitset,
+            (self.data.borrow(), self.entities, self.bitset),
+        )
     }
 
     unsafe fn get(value: &Self::Value, id: Index) -> Self::Type {
@@ -603,7 +611,7 @@ where
     ///
     /// Functions similar to the normal `Storage::get` implementation.
     pub fn get_other(&self, entity: Entity) -> Option<&C> {
-        if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
+        if self.bitset.contains(entity.id()) && self.entities.is_alive(entity) {
             // SAFETY:We just checked the mask.
             Some(unsafe { self.storage.get(entity.id()) })
         } else {

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -7,35 +7,19 @@ use std::{
 use hibitset::BitSet;
 use shred::Fetch;
 
-use crate::join::Join;
+#[nougat::gat(Type)]
+use crate::join::LendJoin;
+use crate::join::{Join, RepeatableLendGet};
 
 #[cfg(feature = "parallel")]
 use crate::join::ParJoin;
 use crate::{
-    storage::{AccessMutReturn, MaskedStorage, Storage, UnprotectedStorage},
+    storage::{
+        AccessMutReturn, DistinctStorage, MaskedStorage, SharedGetMutStorage, Storage,
+        UnprotectedStorage,
+    },
     world::{Component, EntitiesRes, Entity, Index},
 };
-
-/// Specifies that the `RestrictedStorage` cannot run in parallel.
-///
-/// A mutable `RestrictedStorage` can call `get`, `get_mut`, `get_unchecked` and
-/// `get_mut_unchecked` for deferred/restricted access while an immutable
-/// version can only call the immutable accessors.
-pub enum SequentialRestriction {}
-/// Specifies that the `RestrictedStorage` can run in parallel mutably.
-///
-/// This means the storage can only call `get_mut_unchecked` and
-/// `get_unchecked`.
-pub enum MutableParallelRestriction {}
-/// Specifies that the `RestrictedStorage` can run in parallel immutably.
-///
-/// This means that the storage can call `get`, `get_unchecked`.
-pub enum ImmutableParallelRestriction {}
-
-/// Restrictions that are allowed to access `RestrictedStorage::get`.
-pub trait ImmutableAliasing: Sized {}
-impl ImmutableAliasing for SequentialRestriction {}
-impl ImmutableAliasing for ImmutableParallelRestriction {}
 
 /// Similar to a `MaskedStorage` and a `Storage` combined, but restricts usage
 /// to only getting and modifying the components. That means it's not possible
@@ -58,105 +42,20 @@ impl ImmutableAliasing for ImmutableParallelRestriction {}
 ///     fn run(&mut self, (entities, mut some_comps): Self::SystemData) {
 ///         for (entity, mut comps) in (&entities, &mut some_comps.restrict_mut()).join() {
 ///             // Check if the reference is fine to mutate.
-///             if comps.get_unchecked().0 < 5 {
+///             if comps.get().0 < 5 {
 ///                 // Get a mutable reference now.
-///                 let mut mutable = comps.get_mut_unchecked();
+///                 let mut mutable = comps.get_mut();
 ///                 mutable.0 += 1;
 ///             }
 ///         }
 ///     }
 /// }
 /// ```
-pub struct RestrictedStorage<'rf, 'st: 'rf, C, S, B, Restrict>
-where
-    C: Component,
-    S: Borrow<C::Storage> + 'rf,
-    B: Borrow<BitSet> + 'rf,
-{
-    bitset: B,
+pub struct RestrictedStorage<'rf, 'st: 'rf, C, S> {
+    bitset: &'rf BitSet,
     data: S,
     entities: &'rf Fetch<'st, EntitiesRes>,
-    phantom: PhantomData<(C, Restrict)>,
-}
-
-#[cfg(feature = "parallel")]
-unsafe impl<'rf, 'st: 'rf, C, S, B> ParJoin
-    for &'rf mut RestrictedStorage<'rf, 'st, C, S, B, MutableParallelRestriction>
-where
-    C: Component,
-    S: BorrowMut<C::Storage> + 'rf,
-    B: Borrow<BitSet> + 'rf,
-{
-}
-
-#[cfg(feature = "parallel")]
-unsafe impl<'rf, 'st: 'rf, C, S, B, Restrict> ParJoin
-    for &'rf RestrictedStorage<'rf, 'st, C, S, B, Restrict>
-where
-    C: Component,
-    S: Borrow<C::Storage> + 'rf,
-    B: Borrow<BitSet> + 'rf,
-    Restrict: ImmutableAliasing,
-{
-}
-
-impl<'rf, 'st: 'rf, C, S, B, Restrict> Join for &'rf RestrictedStorage<'rf, 'st, C, S, B, Restrict>
-where
-    C: Component,
-    S: Borrow<C::Storage>,
-    B: Borrow<BitSet>,
-{
-    type Mask = &'rf BitSet;
-    type Type = PairedStorage<'rf, 'st, C, &'rf C::Storage, &'rf BitSet, Restrict>;
-    type Value = (&'rf C::Storage, &'rf Fetch<'st, EntitiesRes>, &'rf BitSet);
-
-    unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow(), self.entities, bitset))
-    }
-
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
-        PairedStorage {
-            index: id,
-            storage: value.0,
-            entities: value.1,
-            bitset: value.2,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<'rf, 'st: 'rf, C, S, B, Restrict> Join
-    for &'rf mut RestrictedStorage<'rf, 'st, C, S, B, Restrict>
-where
-    C: Component,
-    S: BorrowMut<C::Storage>,
-    B: Borrow<BitSet>,
-{
-    type Mask = &'rf BitSet;
-    type Type = PairedStorage<'rf, 'st, C, &'rf mut C::Storage, &'rf BitSet, Restrict>;
-    type Value = (
-        &'rf mut C::Storage,
-        &'rf Fetch<'st, EntitiesRes>,
-        &'rf BitSet,
-    );
-
-    unsafe fn open(self) -> (Self::Mask, Self::Value) {
-        let bitset = self.bitset.borrow();
-        (bitset, (self.data.borrow_mut(), self.entities, bitset))
-    }
-
-    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
-        // SAFETY: S-TODO update when changing Join trait
-        let value: &'rf mut Self::Value = unsafe { &mut *(value as *mut Self::Value) };
-        PairedStorage {
-            index: id,
-            storage: value.0,
-            entities: value.1,
-            bitset: value.2,
-            phantom: PhantomData,
-        }
-    }
+    phantom: PhantomData<C>,
 }
 
 impl<'st, T, D> Storage<'st, T, D>
@@ -170,9 +69,7 @@ where
     /// This is returned as a `ParallelRestriction` version since you can only
     /// get immutable components with this which is safe for parallel by
     /// default.
-    pub fn restrict<'rf>(
-        &'rf self,
-    ) -> RestrictedStorage<'rf, 'st, T, &T::Storage, &BitSet, ImmutableParallelRestriction> {
+    pub fn restrict<'rf>(&'rf self) -> RestrictedStorage<'rf, 'st, T, &T::Storage> {
         RestrictedStorage {
             bitset: &self.data.mask,
             data: &self.data.inner,
@@ -190,9 +87,7 @@ where
     /// Builds a mutable `RestrictedStorage` out of a `Storage`. Allows
     /// restricted access to the inner components without allowing
     /// invalidating the bitset for iteration in `Join`.
-    pub fn restrict_mut<'rf>(
-        &'rf mut self,
-    ) -> RestrictedStorage<'rf, 'st, T, &mut T::Storage, &BitSet, SequentialRestriction> {
+    pub fn restrict_mut<'rf>(&'rf mut self) -> RestrictedStorage<'rf, 'st, T, &mut T::Storage> {
         let (mask, data) = self.data.open_mut();
         RestrictedStorage {
             bitset: mask,
@@ -201,100 +96,476 @@ where
             phantom: PhantomData,
         }
     }
+}
 
-    /// Builds a mutable, parallel `RestrictedStorage`,
-    /// does not allow mutably getting other components
-    /// aside from the current iteration.
-    pub fn par_restrict_mut<'rf>(
-        &'rf mut self,
-    ) -> RestrictedStorage<'rf, 'st, T, &mut T::Storage, &BitSet, MutableParallelRestriction> {
-        let (mask, data) = self.data.open_mut();
-        RestrictedStorage {
-            bitset: mask,
-            data,
-            entities: &self.entities,
-            phantom: PhantomData,
+// SAFETY: `open` returns references to corresponding mask and storage values
+// contained in the wrapped `Storage`. Iterating the mask does not repeat
+// indices.
+#[nougat::gat]
+unsafe impl<'rf, 'st: 'rf, C, S> LendJoin for &'rf RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: Borrow<C::Storage>,
+{
+    type Mask = &'rf BitSet;
+    type Type<'next> = PairedStorageRead<'rf, 'st, C>;
+    type Value = (&'rf C::Storage, &'rf Fetch<'st, EntitiesRes>, &'rf BitSet);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = self.bitset.borrow();
+        (bitset, (self.data.borrow(), self.entities, bitset))
+    }
+
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageRead {
+            index: id,
+            storage: value.0,
+            entities: value.1,
+            bitset: value.2,
+        }
+    }
+}
+
+// SAFETY: LendJoin::get impl for this type can safely be called multiple times
+// with the same ID.
+unsafe impl<'rf, 'st: 'rf, C, S> RepeatableLendGet for &'rf RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: Borrow<C::Storage>,
+{
+}
+
+// SAFETY: `open` returns references to corresponding mask and storage values
+// contained in the wrapped `Storage`. Iterating the mask does not repeat
+// indices.
+#[nougat::gat]
+unsafe impl<'rf, 'st: 'rf, C, S> LendJoin for &'rf mut RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: BorrowMut<C::Storage>,
+{
+    type Mask = &'rf BitSet;
+    type Type<'next> = PairedStorageWriteExclusive<'next, 'st, C>;
+    type Value = (
+        &'rf mut C::Storage,
+        &'rf Fetch<'st, EntitiesRes>,
+        &'rf BitSet,
+    );
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = self.bitset.borrow();
+        (bitset, (self.data.borrow_mut(), self.entities, bitset))
+    }
+
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
+    where
+        Self: 'next,
+    {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageWriteExclusive {
+            index: id,
+            storage: value.0,
+            entities: value.1,
+            bitset: value.2,
+        }
+    }
+}
+
+// SAFETY: LendJoin::get impl for this type can safely be called multiple times
+// with the same ID.
+unsafe impl<'rf, 'st: 'rf, C, S> RepeatableLendGet for &'rf mut RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: BorrowMut<C::Storage>,
+{
+}
+
+// SAFETY: `open` returns references to corresponding mask and storage values
+// contained in the wrapped `Storage`. Iterating the mask does not repeat
+// indices.
+unsafe impl<'rf, 'st: 'rf, C, S> Join for &'rf RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: Borrow<C::Storage>,
+{
+    type Mask = &'rf BitSet;
+    type Type = PairedStorageRead<'rf, 'st, C>;
+    type Value = (&'rf C::Storage, &'rf Fetch<'st, EntitiesRes>, &'rf BitSet);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = self.bitset.borrow();
+        (bitset, (self.data.borrow(), self.entities, bitset))
+    }
+
+    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageRead {
+            index: id,
+            storage: value.0,
+            entities: value.1,
+            bitset: value.2,
+        }
+    }
+}
+
+mod shared_get_only {
+    use super::{DistinctStorage, Index, SharedGetMutStorage, UnprotectedStorage};
+    use core::marker::PhantomData;
+
+    /// This type provides a way to ensure only `shared_get_mut` and `get` can
+    /// be called for the lifetime `'a` and that no references previously
+    /// obtained from the storage exist when it is created. While internally
+    /// this is a shared reference, constructing it requires an exclusive borrow
+    /// for the lifetime `'a`.
+    ///
+    /// This is useful for implementation of [`Join`](super::Join) and
+    /// [`ParJoin`](super::ParJoin) for `&mut RestrictedStorage`.
+    pub struct SharedGetOnly<'a, T, S>(&'a S, PhantomData<T>);
+
+    // SAFETY: All fields are required to be `Send` in the where clause. This
+    // also requires `S: DistinctStorage` so that we can freely duplicate
+    // `ShareGetOnly` while preventing `get_mut` from being called from multiple
+    // threads at once.
+    unsafe impl<'a, T, S> Send for SharedGetOnly<'a, T, S>
+    where
+        for<'b> &'b S: Send,
+        PhantomData<T>: Send,
+        S: DistinctStorage,
+    {
+    }
+    // SAFETY: See above.
+    // NOTE: A limitation of this is that `PairedStorageWrite` is not `Sync` in
+    // some cases where it would be fine (we can address this if it is an issue).
+    unsafe impl<'a, T, S> Sync for SharedGetOnly<'a, T, S>
+    where
+        for<'b> &'b S: Sync,
+        PhantomData<T>: Sync,
+        S: DistinctStorage,
+    {
+    }
+
+    impl<'a, T, S> SharedGetOnly<'a, T, S> {
+        pub(super) fn new(storage: &'a mut S) -> Self {
+            Self(storage, PhantomData)
+        }
+
+        pub(crate) fn duplicate(this: &Self) -> Self {
+            Self(this.0, this.1)
+        }
+
+        /// # Safety
+        ///
+        /// May only be called after a call to `insert` with `id` and no
+        /// following call to `remove` with `id` or to `clean`.
+        ///
+        /// A mask should keep track of those states, and an `id` being
+        /// contained in the tracking mask is sufficient to call this method.
+        ///
+        /// There must be no extant aliasing references to this component (i.e.
+        /// obtained with the same `id` via this method or [`Self::get`]).
+        pub(super) unsafe fn get_mut(
+            this: &Self,
+            id: Index,
+        ) -> <S as UnprotectedStorage<T>>::AccessMut<'a>
+        where
+            S: SharedGetMutStorage<T>,
+        {
+            // SAFETY: `Self::new` takes an exclusive reference to this storage,
+            // ensuring there are no extant references to its content at the
+            // time `self` is created and ensuring that only `self` has access
+            // to the storage for its lifetime and the lifetime of the produced
+            // `AccessMutReturn`s (the reference we hold to the storage is not
+            // exposed outside of this module).
+            //
+            // This means we only have to worry about aliasing references being
+            // produced by calling `SharedGetMutStorage::shared_get_mut` (via
+            // this method) or `UnprotectedStorage::get` (via `Self::get`).
+            // Ensuring these don't alias is enforced by the requirements on
+            // this method and `Self::get`.
+            //
+            // `Self` is only `Send`/`Sync` when `S: DistinctStorage`. Note,
+            // that multiple instances of `Self` can be created via `duplicate`
+            // but they can't be sent between threads (nor can shared references
+            // be sent) unless `S: DistinctStorage`. These factors, along with
+            // `Self::new` taking an exclusive reference to the storage, prevent
+            // calling `shared_get_mut` from multiple threads at once unless `S:
+            // DistinctStorage`.
+            //
+            // The remaining safety requirements are passed on to the caller.
+            unsafe { this.0.shared_get_mut(id) }
+        }
+
+        /// # Safety
+        ///
+        /// May only be called after a call to `insert` with `id` and no
+        /// following call to `remove` with `id` or to `clean`.
+        ///
+        /// A mask should keep track of those states, and an `id` being
+        /// contained in the tracking mask is sufficient to call this method.
+        ///
+        /// There must be no extant references obtained from [`Self::get_mut`]
+        /// using the same `id`.
+        pub(super) unsafe fn get(this: &Self, id: Index) -> &'a T
+        where
+            S: UnprotectedStorage<T>,
+        {
+            // SAFETY: Safety requirements passed to the caller.
+            unsafe { this.0.get(id) }
+        }
+    }
+}
+pub use shared_get_only::SharedGetOnly;
+
+// SAFETY: `open` returns references to corresponding mask and storage values
+// contained in the wrapped `Storage`. Iterating the mask does not repeat
+// indices.
+unsafe impl<'rf, 'st: 'rf, C, S> Join for &'rf mut RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: BorrowMut<C::Storage>,
+    C::Storage: SharedGetMutStorage<C>,
+{
+    type Mask = &'rf BitSet;
+    type Type = PairedStorageWriteShared<'rf, C>;
+    type Value = SharedGetOnly<'rf, C, C::Storage>;
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = &self.bitset;
+        let storage = SharedGetOnly::new(self.data.borrow_mut());
+        (bitset, storage)
+    }
+
+    unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageWriteShared {
+            index: id,
+            storage: SharedGetOnly::duplicate(value),
+        }
+    }
+}
+
+// SAFETY: It is safe to call `get` from multiple threads at once since
+// `T::Storage: Sync`. We construct a `PairedStorageRead` which can be used to
+// call `UnprotectedStorage::get` which is safe to call concurrently.
+//
+// `open` returns references to corresponding mask and storage values contained
+// in the wrapped `Storage`.
+unsafe impl<'rf, 'st: 'rf, C, S> ParJoin for &'rf RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: Borrow<C::Storage>,
+    C::Storage: Sync,
+{
+    type Mask = &'rf BitSet;
+    type Type = PairedStorageRead<'rf, 'st, C>;
+    type Value = (&'rf C::Storage, &'rf Fetch<'st, EntitiesRes>, &'rf BitSet);
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = self.bitset.borrow();
+        (bitset, (self.data.borrow(), self.entities, bitset))
+    }
+
+    unsafe fn get(value: &Self::Value, id: Index) -> Self::Type {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageRead {
+            index: id,
+            storage: value.0,
+            entities: value.1,
+            bitset: value.2,
+        }
+    }
+}
+
+// SAFETY: It is safe to call `get` from multiple threads at once since
+// `T::Storage: Sync`. We construct a `PairedStorageSharedWrite` which can be
+// used to call `UnprotectedStorage::get` which is safe to call concurrently and
+// `SharedGetOnly::get_mut` which is safe to call concurrently since we require
+// `C::Storage: DistinctStorage` here.
+//
+// `open` returns references to corresponding mask and storage values contained
+// in the wrapped `Storage`.
+#[cfg(feature = "parallel")]
+unsafe impl<'rf, 'st: 'rf, C, S> ParJoin for &'rf mut RestrictedStorage<'rf, 'st, C, S>
+where
+    C: Component,
+    S: BorrowMut<C::Storage>,
+    C::Storage: Sync + SharedGetMutStorage<C> + DistinctStorage,
+{
+    type Mask = &'rf BitSet;
+    type Type = PairedStorageWriteShared<'rf, C>;
+    type Value = SharedGetOnly<'rf, C, C::Storage>;
+
+    unsafe fn open(self) -> (Self::Mask, Self::Value) {
+        let bitset = &self.bitset;
+        let storage = SharedGetOnly::new(self.data.borrow_mut());
+        (bitset, storage)
+    }
+
+    unsafe fn get(value: &Self::Value, id: Index) -> Self::Type {
+        // NOTE: Methods on this type rely on safety requiments of this method.
+        PairedStorageWriteShared {
+            index: id,
+            storage: SharedGetOnly::duplicate(value),
         }
     }
 }
 
 /// Pairs a storage with an index, meaning that the index is guaranteed to exist
-/// as long as the `PairedStorage<C, S>` exists.
-pub struct PairedStorage<'rf, 'st: 'rf, C, S, B, Restrict> {
+/// as long as the `PairedStorage<C>` exists.
+///
+/// Yielded by `lend_join`/`join`/`par_join` on `&storage.restrict()`.
+pub struct PairedStorageRead<'rf, 'st: 'rf, C: Component> {
     index: Index,
-    storage: S,
-    bitset: B,
+    storage: &'rf C::Storage,
+    bitset: &'rf BitSet,
     entities: &'rf Fetch<'st, EntitiesRes>,
-    phantom: PhantomData<(C, Restrict)>,
 }
 
-impl<'rf, 'st, C, S, B, Restrict> PairedStorage<'rf, 'st, C, S, B, Restrict>
+/// Pairs a storage with an index, meaning that the index is guaranteed to
+/// exist.
+///
+/// Yielded by `join`/`par_join` on `&mut storage.restrict_mut()`.
+pub struct PairedStorageWriteShared<'rf, C: Component> {
+    index: Index,
+    storage: SharedGetOnly<'rf, C, C::Storage>,
+}
+
+// SAFETY: All fields are required to implement `Send` in the where clauses. We
+// also require `C::Storage: DistinctStorage` so that this cannot be sent
+// between threads and then used to call `get_mut` from multiple threads at
+// once.
+unsafe impl<C> Send for PairedStorageWriteShared<'_, C>
 where
     C: Component,
-    S: Borrow<C::Storage>,
-    B: Borrow<BitSet>,
+    Index: Send,
+    for<'a> SharedGetOnly<'a, C, C::Storage>: Send,
+    C::Storage: DistinctStorage,
 {
-    /// Gets the component related to the current entry without checking whether
-    /// the storage has it or not.
-    pub fn get_unchecked(&self) -> &C {
-        unsafe { self.storage.borrow().get(self.index) }
+}
+
+/// Pairs a storage with an index, meaning that the index is guaranteed to
+/// exist.
+///
+/// Yielded by `lend_join` on `&mut storage.restrict_mut()`.
+pub struct PairedStorageWriteExclusive<'rf, 'st: 'rf, C: Component> {
+    index: Index,
+    storage: &'rf mut C::Storage,
+    bitset: &'rf BitSet,
+    entities: &'rf Fetch<'st, EntitiesRes>,
+}
+
+impl<'rf, 'st, C> PairedStorageRead<'rf, 'st, C>
+where
+    C: Component,
+{
+    /// Gets the component related to the current entity.
+    ///
+    /// Note, unlike `get_other` this doesn't need to check whether the
+    /// component is present.
+    pub fn get(&self) -> &C {
+        // SAFETY: This is constructed in the `get` methods of
+        // `LendJoin`/`Join`/`ParJoin` above. These all require that the mask
+        // has been checked.
+        unsafe { self.storage.get(self.index) }
     }
-}
 
-impl<'rf, 'st, C, S, B, Restrict> PairedStorage<'rf, 'st, C, S, B, Restrict>
-where
-    C: Component,
-    S: BorrowMut<C::Storage>,
-    B: Borrow<BitSet>,
-{
-    /// Gets the component related to the current entry without checking whether
-    /// the storage has it or not.
-    pub fn get_mut_unchecked(&mut self) -> AccessMutReturn<'_, C> {
-        // SAFETY: S-TODO update comment when Join trait is fixed.
-        unsafe { self.storage.borrow_mut().get_mut(self.index) }
-    }
-}
-
-impl<'rf, 'st, C, S, B, Restrict> PairedStorage<'rf, 'st, C, S, B, Restrict>
-where
-    C: Component,
-    S: Borrow<C::Storage>,
-    B: Borrow<BitSet>,
-    // Only non parallel and immutable parallel storages can access this.
-    Restrict: ImmutableAliasing,
-{
-    /// Attempts to get the component related to the entity.
+    /// Attempts to get the component related to an arbitrary entity.
     ///
     /// Functions similar to the normal `Storage::get` implementation.
     ///
     /// This only works for non-parallel or immutably parallel
     /// `RestrictedStorage`.
-    pub fn get(&self, entity: Entity) -> Option<&C> {
-        if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
-            Some(unsafe { self.storage.borrow().get(entity.id()) })
+    pub fn get_other(&self, entity: Entity) -> Option<&C> {
+        if self.bitset.contains(entity.id()) && self.entities.is_alive(entity) {
+            // SAFETY:We just checked the mask.
+            Some(unsafe { self.storage.get(entity.id()) })
         } else {
             None
         }
     }
 }
 
-impl<'rf, 'st, C, S, B> PairedStorage<'rf, 'st, C, S, B, SequentialRestriction>
+impl<'rf, C> PairedStorageWriteShared<'rf, C>
 where
     C: Component,
-    S: BorrowMut<C::Storage>,
-    B: Borrow<BitSet>,
+    C::Storage: SharedGetMutStorage<C>,
 {
-    /// Attempts to get the component related to the entity mutably.
+    /// Gets the component related to the current entity.
+    pub fn get(&self) -> &C {
+        // SAFETY: See note in `Self::get_mut` below. The only difference is
+        // that here we take a shared reference which prevents `get_mut` from
+        // being called while the return value is alive, but also allows this
+        // method to still be called again (which is fine).
+        unsafe { SharedGetOnly::get(&self.storage, self.index) }
+    }
+
+    /// Gets the component related to the current entity.
+    pub fn get_mut(&mut self) -> AccessMutReturn<'_, C> {
+        // SAFETY:
+        // * This is constructed in the `get` methods of `Join`/`ParJoin` above.
+        //   These all require that the mask has been checked.
+        // * We also require that either there are no subsequent calls with the
+        //   same `id` (`Join`) or that there are not extant references from a
+        //   call with the same `id` (`ParJoin`). Thus, `id` is unique among
+        //   the instances of `Self` created by the join `get` methods. We then
+        //   tie the lifetime of the returned value to the exclusive borrow of
+        //   self which prevents this or `Self::get` from being called while the
+        //   returned reference is still alive.
+        unsafe { SharedGetOnly::get_mut(&self.storage, self.index) }
+    }
+}
+
+impl<'rf, 'st, C> PairedStorageWriteExclusive<'rf, 'st, C>
+where
+    C: Component,
+{
+    /// Gets the component related to the current entity.
+    ///
+    /// Note, unlike `get_other` this doesn't need to check whether the
+    /// component is present.
+    pub fn get(&self) -> &C {
+        // SAFETY: This is constructed in `LendJoin::get` which requires that
+        // the mask has been checked.
+        unsafe { self.storage.get(self.index) }
+    }
+
+    /// Gets the component related to the current entity.
+    ///
+    /// Note, unlike `get_other_mut` this doesn't need to check whether the
+    /// component is present.
+    pub fn get_mut(&mut self) -> AccessMutReturn<'_, C> {
+        // SAFETY: This is constructed in `LendJoin::get` which requires that
+        // the mask has been checked.
+        unsafe { self.storage.get_mut(self.index) }
+    }
+
+    /// Attempts to get the component related to an arbitrary entity.
+    ///
+    /// Functions similar to the normal `Storage::get` implementation.
+    pub fn get_other(&self, entity: Entity) -> Option<&C> {
+        if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
+            // SAFETY:We just checked the mask.
+            Some(unsafe { self.storage.get(entity.id()) })
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to mutably get the component related to an arbitrary entity.
     ///
     /// Functions similar to the normal `Storage::get_mut` implementation.
     ///
-    /// This only works if this is a non-parallel `RestrictedStorage`,
-    /// otherwise you could access the same component mutably in two different
-    /// threads.
-    pub fn get_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, C>> {
-        if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
-            // SAFETY: S-TODO update comment when Join trait is fixed.
-            Some(unsafe { self.storage.borrow_mut().get_mut(entity.id()) })
+    /// This only works if this is a lending `RestrictedStorage`, otherwise you
+    /// could access the same component mutably via two different
+    /// `PairedStorage`s at the same time.
+    pub fn get_other_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, C>> {
+        if self.bitset.contains(entity.id()) && self.entities.is_alive(entity) {
+            // SAFETY:We just checked the mask.
+            Some(unsafe { self.storage.get_mut(entity.id()) })
         } else {
             None
         }

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -505,7 +505,7 @@ where
 ///     // sound since Pos::Storage is a DistinctStorage
 ///     std::thread::scope(|s| {
 ///         s.spawn(move || {
-///              a.get_mut();
+///             a.get_mut();
 ///         });
 ///     });
 ///     b.get_mut();
@@ -572,15 +572,14 @@ where
     /// Gets the component related to the current entity.
     pub fn get_mut(&mut self) -> AccessMutReturn<'_, C> {
         // SAFETY:
-        // * This is constructed in the `get` methods of `Join`/`ParJoin` above.
-        //   These all require that the mask has been checked.
-        // * We also require that either there are no subsequent calls with the
-        //   same `id` (`Join`) or that there are not extant references from a
-        //   call with the same `id` (`ParJoin`). Thus, `id` is unique among
-        //   the instances of `Self` created by the join `get` methods. We then
-        //   tie the lifetime of the returned value to the exclusive borrow of
-        //   self which prevents this or `Self::get` from being called while the
-        //   returned reference is still alive.
+        // * This is constructed in the `get` methods of `Join`/`ParJoin` above. These
+        //   all require that the mask has been checked.
+        // * We also require that either there are no subsequent calls with the same
+        //   `id` (`Join`) or that there are not extant references from a call with the
+        //   same `id` (`ParJoin`). Thus, `id` is unique among the instances of `Self`
+        //   created by the join `get` methods. We then tie the lifetime of the returned
+        //   value to the exclusive borrow of self which prevents this or `Self::get`
+        //   from being called while the returned reference is still alive.
         unsafe { SharedGetOnly::get_mut(&self.storage, self.index) }
     }
 }

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -147,7 +147,8 @@ where
     }
 
     unsafe fn get(value: &mut Self::Value, id: Index) -> Self::Type {
-        let value: &'rf mut Self::Value = &mut *(value as *mut Self::Value);
+        // SAFETY: S-TODO update when changing Join trait
+        let value: &'rf mut Self::Value = unsafe { &mut *(value as *mut Self::Value) };
         PairedStorage {
             index: id,
             storage: value.0,
@@ -249,6 +250,7 @@ where
     /// Gets the component related to the current entry without checking whether
     /// the storage has it or not.
     pub fn get_mut_unchecked(&mut self) -> AccessMutReturn<'_, C> {
+        // SAFETY: S-TODO update comment when Join trait is fixed.
         unsafe { self.storage.borrow_mut().get_mut(self.index) }
     }
 }
@@ -291,6 +293,7 @@ where
     /// threads.
     pub fn get_mut(&mut self, entity: Entity) -> Option<AccessMutReturn<'_, C>> {
         if self.bitset.borrow().contains(entity.id()) && self.entities.is_alive(entity) {
+            // SAFETY: S-TODO update comment when Join trait is fixed.
             Some(unsafe { self.storage.borrow_mut().get_mut(entity.id()) })
         } else {
             None

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -116,10 +116,7 @@ where
         (bitset, (self.data.borrow(), self.entities, bitset))
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // NOTE: Methods on this type rely on safety requiments of this method.
         PairedStorageRead {
             index: id,
@@ -161,10 +158,7 @@ where
         (bitset, (self.data.borrow_mut(), self.entities, bitset))
     }
 
-    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next>
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(value: &'next mut Self::Value, id: Index) -> Self::Type<'next> {
         // NOTE: Methods on this type rely on safety requiments of this method.
         PairedStorageWriteExclusive {
             index: id,

--- a/src/storage/restrict.rs
+++ b/src/storage/restrict.rs
@@ -356,6 +356,7 @@ where
 // in the wrapped `Storage`.
 //
 // Iterating the mask does not repeat indices.
+#[cfg(feature = "parallel")]
 unsafe impl<'rf, 'st: 'rf, C, S> ParJoin for &'rf RestrictedStorage<'rf, 'st, C, S>
 where
     C: Component,
@@ -460,26 +461,24 @@ where
 ///     type Storage = FlaggedStorage<Self>;
 /// }
 ///
-/// fn main() {
-///     let mut world = World::new();
-///     world.register::<Pos>();
-///     world.create_entity().with(Pos(0.0)).build();
-///     world.create_entity().with(Pos(1.6)).build();
-///     world.create_entity().with(Pos(5.4)).build();
-///     let mut pos = world.write_storage::<Pos>();
+/// let mut world = World::new();
+/// world.register::<Pos>();
+/// world.create_entity().with(Pos(0.0)).build();
+/// world.create_entity().with(Pos(1.6)).build();
+/// world.create_entity().with(Pos(5.4)).build();
+/// let mut pos = world.write_storage::<Pos>();
 ///
-///     let mut restricted_pos = pos.restrict_mut();
-///     let mut joined = (&mut restricted_pos).join();
-///     let mut a = joined.next().unwrap();
-///     let mut b = joined.next().unwrap();
-///     // unsound since Pos::Storage isn't a DistinctStorage
-///     std::thread::scope(|s| {
-///         s.spawn(move || {
-///              a.get_mut();
-///         });
+/// let mut restricted_pos = pos.restrict_mut();
+/// let mut joined = (&mut restricted_pos).join();
+/// let mut a = joined.next().unwrap();
+/// let mut b = joined.next().unwrap();
+/// // unsound since Pos::Storage isn't a DistinctStorage
+/// std::thread::scope(|s| {
+///     s.spawn(move || {
+///          a.get_mut();
 ///     });
-///     b.get_mut();
-/// }
+/// });
+/// b.get_mut();
 /// ```
 /// Should compile since `VecStorage` is a `DistinctStorage`.
 /// ```rust
@@ -490,26 +489,24 @@ where
 ///     type Storage = VecStorage<Self>;
 /// }
 ///
-/// fn main() {
-///     let mut world = World::new();
-///     world.register::<Pos>();
-///     world.create_entity().with(Pos(0.0)).build();
-///     world.create_entity().with(Pos(1.6)).build();
-///     world.create_entity().with(Pos(5.4)).build();
-///     let mut pos = world.write_storage::<Pos>();
+/// let mut world = World::new();
+/// world.register::<Pos>();
+/// world.create_entity().with(Pos(0.0)).build();
+/// world.create_entity().with(Pos(1.6)).build();
+/// world.create_entity().with(Pos(5.4)).build();
+/// let mut pos = world.write_storage::<Pos>();
 ///
-///     let mut restricted_pos = pos.restrict_mut();
-///     let mut joined = (&mut restricted_pos).join();
-///     let mut a = joined.next().unwrap();
-///     let mut b = joined.next().unwrap();
-///     // sound since Pos::Storage is a DistinctStorage
-///     std::thread::scope(|s| {
-///         s.spawn(move || {
-///             a.get_mut();
-///         });
+/// let mut restricted_pos = pos.restrict_mut();
+/// let mut joined = (&mut restricted_pos).join();
+/// let mut a = joined.next().unwrap();
+/// let mut b = joined.next().unwrap();
+/// // sound since Pos::Storage is a DistinctStorage
+/// std::thread::scope(|s| {
+///     s.spawn(move || {
+///         a.get_mut();
 ///     });
-///     b.get_mut();
-/// }
+/// });
+/// b.get_mut();
 /// ```
 fn _dummy() {}
 

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -461,6 +461,8 @@ impl<T> UnprotectedStorage<T> for VecStorage<T> {
         unsafe { maybe_uninit.assume_init_mut() }
     }
 
+    // false positive https://github.com/rust-lang/rust-clippy/issues/10407
+    #[allow(clippy::uninit_vec)]
     unsafe fn insert(&mut self, id: Index, v: T) {
         let id = if Index::BITS > usize::BITS {
             // Saturate the cast to usize::MAX so if this overflows usize the

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -33,7 +33,6 @@ impl<T> Default for BTreeStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -87,7 +86,6 @@ impl<T> Default for HashMapStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -186,7 +184,6 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
@@ -317,7 +314,6 @@ impl<T> Default for NullStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for NullStorage<T> {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, has: B)
@@ -422,7 +418,6 @@ impl<T> SliceAccess<T> for VecStorage<T> {
 }
 
 impl<T> UnprotectedStorage<T> for VecStorage<T> {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, has: B)
@@ -578,7 +573,6 @@ impl<T> UnprotectedStorage<T> for DefaultVecStorage<T>
 where
     T: Default,
 {
-    #[cfg(feature = "nightly")]
     type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -17,9 +17,12 @@ use crate::{
 /// which wraps `T`. The associated type `Element` identifies what
 /// the slices will contain.
 pub trait SliceAccess<T> {
+    /// The type of the underlying data elements.
     type Element;
 
+    /// Returns a slice of the underlying storage.
     fn as_slice(&self) -> &[Self::Element];
+    /// Returns a mutable slice of the underlying storage.
     fn as_mut_slice(&mut self) -> &mut [Self::Element];
 }
 

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -1,12 +1,15 @@
+// TODO: promote to the whole crate
+#![deny(unsafe_op_in_unsafe_fn)]
 //! Different types of storages you can use for your components.
 
-use std::{collections::BTreeMap, mem::MaybeUninit};
+use core::{marker::PhantomData, mem::MaybeUninit, ptr, ptr::NonNull};
+use std::collections::BTreeMap;
 
 use ahash::AHashMap as HashMap;
 use hibitset::BitSetLike;
 
 use crate::{
-    storage::{DistinctStorage, UnprotectedStorage},
+    storage::{DistinctStorage, SyncUnsafeCell, UnprotectedStorage},
     world::Index,
 };
 
@@ -23,7 +26,7 @@ pub trait SliceAccess<T> {
 }
 
 /// BTreeMap-based storage.
-pub struct BTreeStorage<T>(BTreeMap<Index, T>);
+pub struct BTreeStorage<T>(BTreeMap<Index, SyncUnsafeCell<T>>);
 
 impl<T> Default for BTreeStorage<T> {
     fn default() -> Self {
@@ -33,41 +36,44 @@ impl<T> Default for BTreeStorage<T> {
 
 impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
+    type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
     {
-        // nothing to do
+        // nothing to do (components will be dropped with the storage)
     }
 
     unsafe fn get(&self, id: Index) -> &T {
-        &self.0[&id]
+        let ptr = self.0[&id].get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &*ptr }
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
-        self.0.get_mut(&id).unwrap()
+    unsafe fn get_mut(&self, id: Index) -> &mut T {
+        let ptr = self.0[&id].get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &mut *ptr }
     }
 
     unsafe fn insert(&mut self, id: Index, v: T) {
-        self.0.insert(id, v);
+        self.0.insert(id, SyncUnsafeCell::new(v));
     }
 
     unsafe fn remove(&mut self, id: Index) -> T {
-        self.0.remove(&id).unwrap()
+        self.0.remove(&id).unwrap().0.into_inner()
     }
 }
 
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for BTreeStorage<T> {}
 
 /// `HashMap`-based storage. Best suited for rare components.
 ///
 /// This uses the [std::collections::HashMap] internally.
-pub struct HashMapStorage<T>(HashMap<Index, T>);
+pub struct HashMapStorage<T>(HashMap<Index, SyncUnsafeCell<T>>);
 
 impl<T> Default for HashMapStorage<T> {
     fn default() -> Self {
@@ -77,35 +83,38 @@ impl<T> Default for HashMapStorage<T> {
 
 impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
+    type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
     {
-        //nothing to do
+        // nothing to do (components will be dropped with the storage)
     }
 
     unsafe fn get(&self, id: Index) -> &T {
-        &self.0[&id]
+        let ptr = self.0[&id].get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &*ptr }
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
-        self.0.get_mut(&id).unwrap()
+    unsafe fn get_mut(&self, id: Index) -> &mut T {
+        let ptr = self.0[&id].get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &mut *ptr }
     }
 
     unsafe fn insert(&mut self, id: Index, v: T) {
-        self.0.insert(id, v);
+        self.0.insert(id, SyncUnsafeCell::new(v));
     }
 
     unsafe fn remove(&mut self, id: Index) -> T {
-        self.0.remove(&id).unwrap()
+        self.0.remove(&id).unwrap().0.into_inner()
     }
 }
 
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for HashMapStorage<T> {}
 
 /// Dense vector storage. Has a redirection 2-way table
@@ -121,7 +130,7 @@ unsafe impl<T> DistinctStorage for HashMapStorage<T> {}
 /// a particular entity's position within this slice may change
 /// over time.
 pub struct DenseVecStorage<T> {
-    data: Vec<T>,
+    data: Vec<SyncUnsafeCell<T>>,
     entity_id: Vec<Index>,
     data_id: Vec<MaybeUninit<Index>>,
 }
@@ -145,7 +154,13 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
     /// and especially do not correspond with entity IDs.
     #[inline]
     fn as_slice(&self) -> &[Self::Element] {
-        self.data.as_slice()
+        let unsafe_cell_slice_ptr = SyncUnsafeCell::as_cell_of_slice(self.data.as_slice()).get();
+        // SAFETY: The only place that mutably accesses these elements via a
+        // shared reference is the impl of `UnprotectedStorage::get_mut` which
+        // requires callers to avoid calling safe methods with `&self` while
+        // those mutable references are in use and to ensure any references
+        // from those safe methods are no longer alive.
+        unsafe { &*unsafe_cell_slice_ptr }
     }
 
     /// Returns a mutable slice of all the components in this storage.
@@ -154,112 +169,179 @@ impl<T> SliceAccess<T> for DenseVecStorage<T> {
     /// and especially do not correspond with entity IDs.
     #[inline]
     fn as_mut_slice(&mut self) -> &mut [Self::Element] {
-        self.data.as_mut_slice()
+        SyncUnsafeCell::as_slice_mut(self.data.as_mut_slice())
     }
 }
 
 impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
+    type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
     where
         B: BitSetLike,
     {
-        // nothing to do
+        // nothing to do (components will be dropped with the storage)
     }
 
     unsafe fn get(&self, id: Index) -> &T {
-        let did = self.data_id.get_unchecked(id as usize).assume_init();
-        self.data.get_unchecked(did as usize)
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY (get_unchecked and assume_init): Caller required to call
+        // `insert` with this `id` (with no following call to `remove` with that
+        // id or to `clean`).
+        let did = unsafe { self.data_id.get_unchecked(id as usize).assume_init() };
+        // SAFETY: Indices retrieved from `data_id` with a valid `id` will
+        // always correspond to an element in `data`.
+        let ptr = unsafe { self.data.get_unchecked(did as usize) }.get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &*ptr }
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
-        let did = self.data_id.get_unchecked(id as usize).assume_init();
-        self.data.get_unchecked_mut(did as usize)
+    unsafe fn get_mut(&self, id: Index) -> &mut T {
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY (get_unchecked and assume_init): Caller required to call
+        // `insert` with this `id` (with no following call to `remove` with that
+        // id or to `clean`).
+        let did = unsafe { self.data_id.get_unchecked(id as usize).assume_init() };
+        // SAFETY: Indices retrieved from `data_id` with a valid `id` will
+        // always correspond to an element in `data`.
+        let ptr = unsafe { self.data.get_unchecked(did as usize) }.get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &mut *ptr }
     }
 
     unsafe fn insert(&mut self, id: Index, v: T) {
-        let id = id as usize;
+        let id = if Index::BITS > usize::BITS {
+            // Saturate the cast to usize::MAX so if this overflows usize the
+            // allocation below will fail.
+            core::cmp::min(id, usize::MAX as Index) as usize
+        } else {
+            id as usize
+        };
+
         if self.data_id.len() <= id {
-            let delta = id + 1 - self.data_id.len();
+            // NOTE: saturating add ensures that if this computation would
+            // overflow it will instead fail the allocation when calling
+            // reserve.
+            let delta = if Index::BITS >= usize::BITS {
+                id.saturating_add(1)
+            } else {
+                id + 1
+            } - self.data_id.len();
             self.data_id.reserve(delta);
-            self.data_id.set_len(id + 1);
+            // NOTE: Allocation would have failed if this addition would overflow
+            // SAFETY: MaybeUninit elements don't require initialization and
+            // the reserve call ensures the capacity will be sufficient for this
+            // new length.
+            unsafe { self.data_id.set_len(id + 1) };
         }
-        self.data_id
-            .get_unchecked_mut(id)
-            .as_mut_ptr()
-            .write(self.data.len() as Index);
+        // NOTE: `as` cast here is not lossy since the length will be at most
+        // `Index::MAX` if there is still an entity without this component.
+        unsafe { self.data_id.get_unchecked_mut(id) }.write(self.data.len() as Index);
+        // NOTE: `id` originally of the type `Index` so the cast back won't
+        // overflow.
         self.entity_id.push(id as Index);
-        self.data.push(v);
+        self.data.push(SyncUnsafeCell::new(v));
     }
 
     unsafe fn remove(&mut self, id: Index) -> T {
-        let did = self.data_id.get_unchecked(id as usize).assume_init();
+        // NOTE: cast to usize won't overflow since `insert` would have failed
+        // to allocate.
+        // SAFETY (get_unchecked and assume_init): Caller required to have
+        // called `insert` with this `id`.
+        let did = unsafe { self.data_id.get_unchecked(id as usize).assume_init() };
         let last = *self.entity_id.last().unwrap();
-        self.data_id
-            .get_unchecked_mut(last as usize)
-            .as_mut_ptr()
-            .write(did);
+        // NOTE: cast to usize won't overflow since `insert` would have failed
+        // to allocate.
+        // SAFETY: indices in `self.entity_id` correspond to components present
+        // in this storage so this will be in-bounds.
+        unsafe { self.data_id.get_unchecked_mut(last as usize) }.write(did);
+        // NOTE: casting the index in the dense data array to usize won't
+        // overflow since the maximum number of components if limited to
+        // `Index::MAX + 1`.
         self.entity_id.swap_remove(did as usize);
-        self.data.swap_remove(did as usize)
+        self.data.swap_remove(did as usize).0.into_inner()
     }
 }
 
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for DenseVecStorage<T> {}
 
 /// A null storage type, used for cases where the component
 /// doesn't contain any data and instead works as a simple flag.
-pub struct NullStorage<T>(T);
+pub struct NullStorage<T>(PhantomData<T>);
 
-impl<T> UnprotectedStorage<T> for NullStorage<T>
-where
-    T: Default,
-{
-    #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
-
-    unsafe fn clean<B>(&mut self, _has: B)
-    where
-        B: BitSetLike,
-    {
-    }
-
-    unsafe fn get(&self, _: Index) -> &T {
-        &self.0
-    }
-
-    unsafe fn get_mut(&mut self, _: Index) -> &mut T {
-        &mut self.0
-    }
-
-    unsafe fn insert(&mut self, _: Index, _: T) {}
-
-    unsafe fn remove(&mut self, _: Index) -> T {
-        Default::default()
-    }
-}
-
-impl<T> Default for NullStorage<T>
-where
-    T: Default,
-{
+impl<T> Default for NullStorage<T> {
     fn default() -> Self {
-        use std::mem::size_of;
+        use core::mem::size_of;
 
         assert_eq!(size_of::<T>(), 0, "NullStorage can only be used with ZST");
 
-        NullStorage(Default::default())
+        NullStorage(PhantomData)
     }
 }
 
-/// This is safe because you cannot mutate ZSTs.
+impl<T> UnprotectedStorage<T> for NullStorage<T> {
+    #[cfg(feature = "nightly")]
+    type AccessMut<'a> = &'a mut T where T: 'a;
+
+    unsafe fn clean<B>(&mut self, has: B)
+    where
+        B: BitSetLike,
+    {
+        for id in has.iter() {
+            // SAFETY: Caller required to provide mask that keeps track of the
+            // existing elements, so every `id` is valid to use with `remove`.
+            unsafe { self.remove(id) };
+        }
+    }
+
+    unsafe fn get(&self, _: Index) -> &T {
+        // SAFETY: Because the caller is required by the safety docs to first
+        // insert a component with this index, this corresponds to an instance
+        // of the ZST we conceptually own. The caller also must manage the
+        // aliasing of accesses via get/get_mut.
+        //
+        // Self::default asserts that `T` is a ZST which makes generating a
+        // reference from a dangling pointer not UB.
+        unsafe { &*NonNull::dangling().as_ptr() }
+    }
+
+    unsafe fn get_mut(&self, _: Index) -> &mut T {
+        // SAFETY: Because the caller is required by the safety docs to first
+        // insert a component with this index, this corresponds to an instance
+        // of the ZST we conceptually own. The caller also must manage the
+        // aliasing of accesses via get/get_mut.
+        //
+        // Self::default asserts that `T` is a ZST which makes generating a
+        // reference from a dangling pointer not UB.
+        unsafe { &mut *NonNull::dangling().as_ptr() }
+    }
+
+    unsafe fn insert(&mut self, _: Index, v: T) {
+        // We rely on the caller tracking the presence of the ZST via the mask.
+        //
+        // We need to forget this to avoid the drop impl from running so the
+        // storage logically is taking ownership of this instance of the ZST.
+        core::mem::forget(v)
+    }
+
+    unsafe fn remove(&mut self, _: Index) -> T {
+        // SAFETY: Because the caller is required by the safety docs to first
+        // insert a component with this index, this corresponds to an instance
+        // of the ZST we conceptually own.
+        //
+        // Self::default asserts that `T` is a ZST which makes reading from a
+        // dangling pointer not UB.
+        unsafe { ptr::read(NonNull::dangling().as_ptr()) }
+    }
+}
+
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for NullStorage<T> {}
 
 /// Vector storage. Uses a simple `Vec`. Supposed to have maximum
@@ -269,7 +351,7 @@ unsafe impl<T> DistinctStorage for NullStorage<T> {}
 /// entity IDs. These can be compared to other `VecStorage`s, to
 /// other `DefaultVecStorage`s, and to `Entity::id()`s for live
 /// entities.
-pub struct VecStorage<T>(Vec<MaybeUninit<T>>);
+pub struct VecStorage<T>(Vec<SyncUnsafeCell<MaybeUninit<T>>>);
 
 impl<T> Default for VecStorage<T> {
     fn default() -> Self {
@@ -282,62 +364,117 @@ impl<T> SliceAccess<T> for VecStorage<T> {
 
     #[inline]
     fn as_slice(&self) -> &[Self::Element] {
-        self.0.as_slice()
+        let unsafe_cell_slice_ptr = SyncUnsafeCell::as_cell_of_slice(self.0.as_slice()).get();
+        // SAFETY: The only place that mutably accesses these elements via a
+        // shared reference is the impl of `UnprotectedStorage::get_mut` which
+        // requires callers to avoid calling safe methods with `&self` while
+        // those mutable references are in use.
+        unsafe { &*unsafe_cell_slice_ptr }
     }
 
     #[inline]
     fn as_mut_slice(&mut self) -> &mut [Self::Element] {
-        self.0.as_mut_slice()
+        SyncUnsafeCell::as_slice_mut(self.0.as_mut_slice())
     }
 }
 
 impl<T> UnprotectedStorage<T> for VecStorage<T> {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
+    type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, has: B)
     where
         B: BitSetLike,
     {
-        use std::ptr;
         for (i, v) in self.0.iter_mut().enumerate() {
+            // NOTE: `as` cast is safe since the index used for insertion is a
+            // `u32` so the indices will never be over `u32::MAX`.
+            const _: Index = 0u32;
             if has.contains(i as u32) {
                 // drop in place
-                ptr::drop_in_place(&mut *v.as_mut_ptr());
+                let v_inner = v.get_mut();
+                // SAFETY: Present in the provided mask. All components are
+                // considered removed after a call to `clean`.
+                unsafe { v_inner.assume_init_drop() };
             }
         }
-        self.0.set_len(0);
     }
 
     unsafe fn get(&self, id: Index) -> &T {
-        &*self.0.get_unchecked(id as usize).as_ptr()
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY: Caller required to call `insert` with this `id` (with no
+        // following call to `remove` with that id or to `clean`).
+        let ptr = unsafe { self.0.get_unchecked(id as usize) }.get();
+        // SAFETY: Caller required to manage aliasing between this and
+        // `get_mut`.
+        let maybe_uninit = unsafe { &*ptr };
+        // SAFETY: Requirement to have `insert`ed this component ensures that it
+        // will be initialized.
+        unsafe { maybe_uninit.assume_init_ref() }
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
-        &mut *self.0.get_unchecked_mut(id as usize).as_mut_ptr()
+    unsafe fn get_mut(&self, id: Index) -> &mut T {
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY: Caller required to call `insert` with this `id` (with no
+        // following call to `remove` with that id or to `clean`).
+        let ptr = unsafe { self.0.get_unchecked(id as usize) }.get();
+        // SAFETY: Caller required to manage aliasing (both ensuring
+        // `get_mut`/`get` is called without aliasing refs returned here, and
+        // ensuring other safe methods that take `&self` aren't called while the
+        // returned mutable references are alive).
+        let maybe_uninit = unsafe { &mut *ptr };
+        // SAFETY: Requirement to have `insert`ed this component ensures that it
+        // will be initialized.
+        unsafe { maybe_uninit.assume_init_mut() }
     }
 
     unsafe fn insert(&mut self, id: Index, v: T) {
-        let id = id as usize;
+        let id = if Index::BITS > usize::BITS {
+            // Saturate the cast to usize::MAX so if this overflows usize the
+            // allocation below will fail.
+            core::cmp::min(id, usize::MAX as Index) as usize
+        } else {
+            id as usize
+        };
+
         if self.0.len() <= id {
-            let delta = id + 1 - self.0.len();
+            // NOTE: saturating add ensures that if this computation would
+            // overflow it will instead fail the allocation when calling
+            // reserve.
+            let delta = if Index::BITS >= usize::BITS {
+                id.saturating_add(1)
+            } else {
+                id + 1
+            } - self.0.len();
             self.0.reserve(delta);
-            self.0.set_len(id + 1);
+            // NOTE: Allocation would have failed if this addition would overflow
+            // SAFETY: MaybeUninit elements don't require initialization and
+            // the reserve call ensures the capacity will be sufficient for this
+            // new length.
+            unsafe { self.0.set_len(id + 1) };
         }
         // Write the value without reading or dropping
         // the (currently uninitialized) memory.
-        *self.0.get_unchecked_mut(id as usize) = MaybeUninit::new(v);
+        // SAFETY: The length of the vec was extended to contain this index
+        // above.
+        unsafe { self.0.get_unchecked_mut(id) }.get_mut().write(v);
     }
 
     unsafe fn remove(&mut self, id: Index) -> T {
-        use std::ptr;
-        ptr::read(self.get(id))
+        // SAFETY: Caller required to have called `insert` with this `id`.
+        // Exclusive `&mut self` ensures no aliasing is occuring.
+        let component_ref = unsafe { self.get(id) };
+        // SAFETY: Caller not allowed to call other methods that access this
+        // `id` as an initialized value after this call to `remove` so it is
+        // safe to move out of this.
+        unsafe { ptr::read(component_ref) }
     }
 }
 
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for VecStorage<T> {}
 
 /// Vector storage, like `VecStorage`, but allows safe access to the
@@ -348,11 +485,32 @@ unsafe impl<T> DistinctStorage for VecStorage<T> {}
 /// `as_slice()` and `as_mut_slice()` indices correspond to entity IDs.
 /// These can be compared to other `DefaultVecStorage`s, to other
 /// `VecStorage`s, and to `Entity::id()`s for live entities.
-pub struct DefaultVecStorage<T>(Vec<T>);
+pub struct DefaultVecStorage<T>(Vec<SyncUnsafeCell<T>>);
 
 impl<T> Default for DefaultVecStorage<T> {
     fn default() -> Self {
         Self(Default::default())
+    }
+}
+
+impl<T> SliceAccess<T> for DefaultVecStorage<T> {
+    type Element = T;
+
+    /// Returns a slice of all the components in this storage.
+    #[inline]
+    fn as_slice(&self) -> &[Self::Element] {
+        let unsafe_cell_slice_ptr = SyncUnsafeCell::as_cell_of_slice(self.0.as_slice()).get();
+        // SAFETY: The only place that mutably accesses these elements via a
+        // shared reference is the impl of `UnprotectedStorage::get_mut` which
+        // requires callers to avoid calling safe methods with `&self` while
+        // those mutable references are in use.
+        unsafe { &*unsafe_cell_slice_ptr }
+    }
+
+    /// Returns a mutable slice of all the components in this storage.
+    #[inline]
+    fn as_mut_slice(&mut self) -> &mut [Self::Element] {
+        SyncUnsafeCell::as_slice_mut(self.0.as_mut_slice())
     }
 }
 
@@ -361,10 +519,7 @@ where
     T: Default,
 {
     #[cfg(feature = "nightly")]
-    type AccessMut<'a>
-    where
-        T: 'a,
-    = &'a mut T;
+    type AccessMut<'a> = &'a mut T where T: 'a;
 
     unsafe fn clean<B>(&mut self, _has: B)
     where
@@ -374,51 +529,50 @@ where
     }
 
     unsafe fn get(&self, id: Index) -> &T {
-        self.0.get_unchecked(id as usize)
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY: See `VecStorage` impl.
+        let ptr = unsafe { self.0.get_unchecked(id as usize) }.get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &*ptr }
     }
 
-    unsafe fn get_mut(&mut self, id: Index) -> &mut T {
-        self.0.get_unchecked_mut(id as usize)
+    unsafe fn get_mut(&self, id: Index) -> &mut T {
+        // NOTE: `as` cast is not lossy since insert would have encountered an
+        // allocation failure if this would overflow `usize.`
+        // SAFETY: See `VecStorage` impl.
+        let ptr = unsafe { self.0.get_unchecked(id as usize) }.get();
+        // SAFETY: See `VecStorage` impl.
+        unsafe { &mut *ptr }
     }
 
     unsafe fn insert(&mut self, id: Index, v: T) {
-        let id = id as usize;
+        let id = if Index::BITS > usize::BITS {
+            // Saturate the cast to usize::MAX so if this overflows usize the
+            // allocation below will fail.
+            core::cmp::min(id, usize::MAX as Index) as usize
+        } else {
+            id as usize
+        };
 
         if self.0.len() <= id {
             // fill all the empty slots with default values
             self.0.resize_with(id, Default::default);
             // store the desired value
-            self.0.push(v)
+            self.0.push(SyncUnsafeCell::new(v))
         } else {
             // store the desired value directly
-            self.0[id] = v;
+            *self.0[id].get_mut() = v;
         }
     }
 
     unsafe fn remove(&mut self, id: Index) -> T {
-        // make a new default value
-        let mut v = T::default();
-        // swap it into the vec
-        std::ptr::swap(self.0.get_unchecked_mut(id as usize), &mut v);
-        // return the old value
-        v
+        // Take value leaving a default instance behind
+        // SAFETY: Caller required to have called `insert` with this `id`.
+        core::mem::take(unsafe { self.0.get_unchecked_mut(id as usize) }.get_mut())
     }
 }
 
+// SAFETY: `get_mut` doesn't perform any overlapping mutable accesses when
+// provided distinct indices.
 unsafe impl<T> DistinctStorage for DefaultVecStorage<T> {}
-
-impl<T> SliceAccess<T> for DefaultVecStorage<T> {
-    type Element = T;
-
-    /// Returns a slice of all the components in this storage.
-    #[inline]
-    fn as_slice(&self) -> &[Self::Element] {
-        self.0.as_slice()
-    }
-
-    /// Returns a mutable slice of all the components in this storage.
-    #[inline]
-    fn as_mut_slice(&mut self) -> &mut [Self::Element] {
-        self.0.as_mut_slice()
-    }
-}

--- a/src/storage/storages.rs
+++ b/src/storage/storages.rs
@@ -1,5 +1,3 @@
-// TODO: promote to the whole crate
-#![deny(unsafe_op_in_unsafe_fn)]
 //! Different types of storages you can use for your components.
 
 use core::{marker::PhantomData, mem::MaybeUninit, ptr, ptr::NonNull};
@@ -42,7 +40,7 @@ impl<T> UnprotectedStorage<T> for BTreeStorage<T> {
     where
         B: BitSetLike,
     {
-        // nothing to do (components will be dropped with the storage)
+        self.0.clear();
     }
 
     unsafe fn get(&self, id: Index) -> &T {
@@ -89,7 +87,7 @@ impl<T> UnprotectedStorage<T> for HashMapStorage<T> {
     where
         B: BitSetLike,
     {
-        // nothing to do (components will be dropped with the storage)
+        self.0.clear();
     }
 
     unsafe fn get(&self, id: Index) -> &T {
@@ -181,7 +179,12 @@ impl<T> UnprotectedStorage<T> for DenseVecStorage<T> {
     where
         B: BitSetLike,
     {
-        // nothing to do (components will be dropped with the storage)
+        // NOTE: clearing `data` may panic due to drop impls. So to makes sure
+        // everything is cleared and ensure `remove` is sound we clear `data`
+        // last.
+        self.data_id.clear();
+        self.entity_id.clear();
+        self.data.clear();
     }
 
     unsafe fn get(&self, id: Index) -> &T {

--- a/src/storage/sync_unsafe_cell.rs
+++ b/src/storage/sync_unsafe_cell.rs
@@ -1,5 +1,3 @@
-// TODO: promote to the whole crate
-#![deny(unsafe_op_in_unsafe_fn)]
 //! Stand in for core::cell::SyncUnsafeCell since that is still unstable.
 //!
 //! TODO: Remove when core::cell::SyncUnsafeCell is stabilized

--- a/src/storage/sync_unsafe_cell.rs
+++ b/src/storage/sync_unsafe_cell.rs
@@ -1,0 +1,53 @@
+// TODO: promote to the whole crate
+#![deny(unsafe_op_in_unsafe_fn)]
+//! Stand in for core::cell::SyncUnsafeCell since that is still unstable.
+//!
+//! TODO: Remove when core::cell::SyncUnsafeCell is stabilized
+
+use core::cell::UnsafeCell;
+use core::ops::{Deref, DerefMut};
+
+#[repr(transparent)]
+pub struct SyncUnsafeCell<T: ?Sized>(pub UnsafeCell<T>);
+
+// SAFETY: Proper synchronization is left to the user of the unsafe `get` call.
+// `UnsafeCell` itself doesn't implement `Sync` to prevent accidental mis-use.
+unsafe impl<T: ?Sized + Sync> Sync for SyncUnsafeCell<T> {}
+
+impl<T> SyncUnsafeCell<T> {
+    pub fn new(value: T) -> Self {
+        Self(UnsafeCell::new(value))
+    }
+
+    pub fn as_cell_of_slice(slice: &[Self]) -> &SyncUnsafeCell<[T]> {
+        // SAFETY: `T` has the same memory layout as `SyncUnsafeCell<T>`.
+        unsafe { &*(slice as *const [Self] as *const SyncUnsafeCell<[T]>) }
+    }
+
+    pub fn as_slice_mut(slice: &mut [Self]) -> &mut [T] {
+        // SAFETY: `T` has the same memory layout as `SyncUnsafeCell<T>` and we
+        // have a mutable reference which means the `SyncUnsafeCell` can be
+        // safely removed since we have exclusive access here.
+        unsafe { &mut *(slice as *mut [Self] as *mut [T]) }
+    }
+}
+
+impl<T: ?Sized> Deref for SyncUnsafeCell<T> {
+    type Target = UnsafeCell<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: ?Sized> DerefMut for SyncUnsafeCell<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T: Default> Default for SyncUnsafeCell<T> {
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}

--- a/src/storage/tests.rs
+++ b/src/storage/tests.rs
@@ -944,7 +944,7 @@ mod test {
             assert!(!removed.contains(entity.id()));
         }
 
-        for (_, mut comp) in (&w.entities(), &mut s1).join() {
+        for (_, comp) in (&w.entities(), &mut s1).join() {
             comp.0 += 1;
         }
 

--- a/src/storage/track.rs
+++ b/src/storage/track.rs
@@ -69,7 +69,7 @@ where
     /// Returns the event channel for insertions/removals/modifications of this
     /// storage's components.
     pub fn channel_mut(&mut self) -> &mut EventChannel<ComponentEvent> {
-        unsafe { self.open() }.1.channel_mut()
+        self.data.inner.channel_mut()
     }
 
     /// Starts tracking component events. Note that this reader id should be
@@ -89,6 +89,6 @@ where
     /// not emitted.
     #[cfg(feature = "storage-event-control")]
     pub fn set_event_emission(&mut self, emit: bool) {
-        unsafe { self.open() }.1.set_event_emission(emit);
+        self.data.inner.set_event_emission(emit);
     }
 }

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -96,7 +96,7 @@ impl Allocator {
         Ok(())
     }
 
-    /// Kills and entity atomically (will be updated when the allocator is
+    /// Kills an entity atomically (will be updated when the allocator is
     /// maintained).
     pub fn kill_atomic(&self, e: Entity) -> Result<(), WrongGeneration> {
         if !self.is_alive(e) {

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -11,7 +11,12 @@ use shred::Read;
 use crate::join::LendJoin;
 #[cfg(feature = "parallel")]
 use crate::join::ParJoin;
-use crate::{error::WrongGeneration, join::Join, storage::WriteStorage, world::Component};
+use crate::{
+    error::WrongGeneration,
+    join::{Join, RepeatableLendGet},
+    storage::WriteStorage,
+    world::Component,
+};
 
 /// An index is basically the id of an `Entity`.
 pub type Index = u32;
@@ -342,6 +347,10 @@ unsafe impl<'a> LendJoin for &'a EntitiesRes {
         Entity(id, gen)
     }
 }
+
+// SAFETY: <EntitiesRes as LendJoin>::get does not rely on only being called once
+// with a particular ID.
+unsafe impl<'a> RepeatableLendGet for &'a EntitiesRes {}
 
 // SAFETY: It is safe to retrieve elements with any `id` regardless of the mask.
 unsafe impl<'a> Join for &'a EntitiesRes {

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -207,9 +207,8 @@ impl Allocator {
     }
 
     fn update_generation_length(&mut self, i: usize) {
-        if self.generations.len() <= i as usize {
-            self.generations
-                .resize(i as usize + 1, ZeroableGeneration(None));
+        if self.generations.len() <= i {
+            self.generations.resize(i + 1, ZeroableGeneration(None));
         }
     }
 }

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -347,8 +347,8 @@ unsafe impl<'a> LendJoin for &'a EntitiesRes {
     }
 }
 
-// SAFETY: <EntitiesRes as LendJoin>::get does not rely on only being called once
-// with a particular ID.
+// SAFETY: <EntitiesRes as LendJoin>::get does not rely on only being called
+// once with a particular ID.
 unsafe impl<'a> RepeatableLendGet for &'a EntitiesRes {}
 
 // SAFETY: It is safe to retrieve elements with any `id` regardless of the mask.

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -330,7 +330,10 @@ unsafe impl<'a> LendJoin for &'a EntitiesRes {
         (BitSetOr(&self.alloc.alive, &self.alloc.raised), self)
     }
 
-    unsafe fn get(v: &mut &'a EntitiesRes, id: Index) -> Entity {
+    unsafe fn get<'next>(v: &'next mut &'a EntitiesRes, id: Index) -> Entity
+    where
+        Self: 'next,
+    {
         let gen = v
             .alloc
             .generation(id)

--- a/src/world/entity.rs
+++ b/src/world/entity.rs
@@ -334,10 +334,7 @@ unsafe impl<'a> LendJoin for &'a EntitiesRes {
         (BitSetOr(&self.alloc.alive, &self.alloc.raised), self)
     }
 
-    unsafe fn get<'next>(v: &'next mut &'a EntitiesRes, id: Index) -> Entity
-    where
-        Self: 'next,
-    {
+    unsafe fn get<'next>(v: &'next mut &'a EntitiesRes, id: Index) -> Entity {
         let gen = v
             .alloc
             .generation(id)

--- a/src/world/world_ext.rs
+++ b/src/world/world_ext.rs
@@ -320,7 +320,7 @@ impl WorldExt for World {
         self.entry()
             .or_insert_with(move || MaskedStorage::<T>::new(storage()));
         self.fetch_mut::<MetaTable<dyn AnyStorage>>()
-            .register(&*self.fetch::<MaskedStorage<T>>());
+            .register::<MaskedStorage<T>>();
     }
 
     fn add_resource<T: Resource>(&mut self, res: T) {
@@ -414,8 +414,8 @@ impl WorldExt for World {
     }
 
     fn delete_components(&mut self, delete: &[Entity]) {
-        for storage in self.fetch_mut::<MetaTable<dyn AnyStorage>>().iter_mut(self) {
-            storage.drop(delete);
+        for mut storage in self.fetch_mut::<MetaTable<dyn AnyStorage>>().iter_mut(self) {
+            (&mut *storage).drop(delete);
         }
     }
 }

--- a/src/world/world_ext.rs
+++ b/src/world/world_ext.rs
@@ -415,7 +415,7 @@ impl WorldExt for World {
 
     fn delete_components(&mut self, delete: &[Entity]) {
         for mut storage in self.fetch_mut::<MetaTable<dyn AnyStorage>>().iter_mut(self) {
-            (&mut *storage).drop(delete);
+            (*storage).drop(delete);
         }
     }
 }

--- a/tests/no_parallel.rs
+++ b/tests/no_parallel.rs
@@ -1,4 +1,5 @@
 #![cfg(not(feature = "parallel"))]
+// TODO: ensure we run these with miri too
 
 use std::rc::Rc;
 

--- a/tests/no_parallel.rs
+++ b/tests/no_parallel.rs
@@ -1,5 +1,4 @@
 #![cfg(not(feature = "parallel"))]
-// TODO: ensure we run these with miri too
 
 use std::rc::Rc;
 

--- a/tests/saveload.rs
+++ b/tests/saveload.rs
@@ -56,6 +56,7 @@ mod tests {
     struct TupleSerdeType(u32);
 
     #[derive(Clone)]
+    #[allow(dead_code)]
     struct UnserializableType {
         inner: u32,
     }
@@ -67,6 +68,7 @@ mod tests {
     }
 
     #[derive(Serialize, Deserialize, Clone)]
+    #[allow(dead_code)]
     struct ComplexSerdeType {
         #[serde(skip, default)]
         opaque: UnserializableType,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -550,7 +550,7 @@ fn par_join_many_entities_and_systems() {
 }
 
 #[test]
-fn getting_specific_entity_with_join() {
+fn getting_specific_entity_with_lend_join() {
     let mut world = create_world();
     world
         .create_entity()
@@ -565,12 +565,16 @@ fn getting_specific_entity_with_join() {
 
         assert_eq!(
             Some((&CompInt(1), &mut CompBool(true))),
-            (&ints, &mut bools).join().get(entity, &world.entities())
+            (&ints, &mut bools)
+                .lend_join()
+                .get(entity, &world.entities())
         );
         bools.remove(entity);
         assert_eq!(
             None,
-            (&ints, &mut bools).join().get(entity, &world.entities())
+            (&ints, &mut bools)
+                .lend_join()
+                .get(entity, &world.entities())
         );
         entity
     };
@@ -584,7 +588,9 @@ fn getting_specific_entity_with_join() {
     let mut bools = world.write_storage::<CompBool>();
     assert_eq!(
         None,
-        (&ints, &mut bools).join().get(entity, &world.entities())
+        (&ints, &mut bools)
+            .lend_join()
+            .get(entity, &world.entities())
     );
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,9 @@ use specs::{
     world::{Builder, WorldExt},
 };
 
+// Make tests finish in reasonable time with miri
+const ITERATIONS: u32 = if cfg!(miri) { 20 } else { 1000 };
+
 #[derive(Clone, Debug, PartialEq)]
 struct CompInt(i8);
 
@@ -97,7 +100,7 @@ fn dynamic_create() {
     let mut world = create_world();
     let mut dispatcher = DispatcherBuilder::new().with(Sys, "s", &[]).build();
 
-    for _ in 0..1_000 {
+    for _ in 0..ITERATIONS {
         dispatcher.dispatch(&mut world);
     }
 }
@@ -118,7 +121,7 @@ fn dynamic_deletion() {
     let mut world = create_world();
     let mut dispatcher = DispatcherBuilder::new().with(Sys, "s", &[]).build();
 
-    for _ in 0..1_000 {
+    for _ in 0..ITERATIONS {
         dispatcher.dispatch(&mut world);
     }
 }


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

Fixes https://github.com/amethyst/specs/issues/647

See API changes section for description.

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [x] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## Todo
* [x] Add more to PR description
* [x] Fix this https://github.com/amethyst/specs/pull/765#discussion_r1131532958
* [ ] ~~LendJoin uses `nougat` since I started working on it before GATs stabilized. I kept it because I thought it might be useful to add more iterator combinators (some combinators are currently impossible to implement with actual GATs). However, I think it would probably be prudent to remove this and use regular GATs for simplicity.~~ So I wanted to remove `nougat` but it turns out that I can't implement `for_each` without it (without either running into requiring `Self: 'static` due to `for<'_>` hrtb or not being able to have lifetimes in the GAT (`LendJoin::Type<'next>`) that aren't `'next` and aren't `'static`.
* [x] May want to create a quick 0.19.0 release first? See https://github.com/amethyst/specs/issues/764
* [x] Compare performance to make sure no significant regressions were introduced (and to satisfy my curiosity)
    * [x] Benchmarks (I compared several versions of `specs` using `ecs_bench_suite`, there is _maybe_ a 3% increase in `add_remove`, there was a significant increase (10+%) in deletion times due to `shred::MetaTable` changes, so I introduce a `nightly` feature that enables a more efficient implementation using `ptr_metadata`, `fetch` heavy code shows improvements due to the use of `atomic_refcell` in `shred` instead of the custom atomic cell implementation) 
    * [x] Veloren server
* [x] Publish new versions of `hibitset` and `shred` to crates.io and use those instead of git dependencies.
* [x] Update changelog

## API changes

This is a breaking change.

This PR fixes several soundness issues that I encountered when working on #737. These include:
* The `Join` implementation for `specs::storage::Entries` allows creating aliasing `&mut` references to the underlying storage (i.e. when not using the `JoinIter` as a lending/streaming iterator).
* The `Join` implementation and API of `specs::storage::RestrictedStorage` similarly can create mutable aliasing references to storages as well as to a specific component.
* The `Join` implementation of `Storage` allowed `DerefFlaggedStorage` to create aliasing `&mut` references to the internal events channel.
* `JoinIter::get` allows creating aliasing mutable refs, see #647. 
* Parallel iteration creates aliasing `&mut Join::Value` references.
* Under stacked borrows certain Join::get implementations were invalidating previously returned mutable references (e.g. by creating a slice reference to the whole underlying storage).

Many (but not all) of these issues stem from artificially lengthening the lifetime of the `&mut Join::Value` within `Join::get` implementations. We now avoid this and leverage alternative mechanisms including interior mutability and lending iteration.

In more detail, we:
* Introduce `LendJoin` trait or lending (aka streaming) iteration of joined values.
* Make some things like `Entries` now only implement `LendJoin` (i.e. remove unsound `Join` implementations).
* Implement `LendJoin` for everything that implements `Join`(manually, not a blanket impl since there are difference in the implementation).
* Move `JoinIter::get` to `JoinLendIter::get`.
* Add the `RepeatableLendGet` trait (which `JoinLendIter::get` requires). This is to facilitate destructive implementations of `LendJoin` where getting the same index more than once would be unsound (i.e. literally just the owned implementation of `LendJoin` for  `ChangeSet` which removes values as it iterates).
* Refactor `ParJoin` trait to not rely on `Join` implementation so we have additional flexibility to use different implementations and keep `&mut Join::Value` in `Join::get`.
* Make `Join`  an `unsafe` trait. The new `LendJoin` trait is also `unsafe` to implement.
* `Storage` no longer implements mutable `Join`s (the non-lending variant) for all `UnprotectedStorage`s. Instead this implementation requires that the storage implements `SharedGetMutStorage`. The trait which provides a `shared_get_mut(&self, id: Index)` method. Notice this takes a shared reference. Storages that can soundly implement this wrap their components in `UnsafeCell` to allow constructing a mutable reference from a shared reference.
* Revamp many pieces of safety documentation.
* Add `#![deny(unsafe_op_in_unsafe_fn)]` to make it easier to identify and document unsafe operations.
    
To try to catch any remaining UB, I ran the available tests under [Miri ](https://github.com/rust-lang/miri). This also identified some issues in dependencies for which I have submitted PRs to fix:
* https://github.com/amethyst/shred/pull/223
* https://github.com/amethyst/shred/pull/226
* https://github.com/amethyst/hibitset/pull/61
    
(We need to publish new versions of these to crates.io)

This PR adds Miri to the CI.

Additionally, `specs` exposed a `nightly` cargo feature that enabled additional APIs using GATs. Since GATs are now stabilized, I bumped the MSRV to be able to eliminate this feature and remove a bunch of `cfg` complexity.
   
Also I introduced `AccessMut` trait which is similar to `DerefMut` except it requires explicit use. The associated type`UnprotectedStorage::AccessMut<'_>` now requires `AccessMut` instead of `DerefMut`. This is to faciliate my work in https://github.com/amethyst/specs/pull/737 where I am exploring a flagged storage type that makes generating modification events more explicit. A blanket implementation of `AccessMut` for anything implementing `DerefMut` is included.
 
<!-- Please make it clear if your change is breaking. -->
