### PR TITLE
Delete components after killing entities to avoid clearing components when the entity has the wrong generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        toolchain: [stable, beta, nightly, 1.60.0]
+        toolchain: [stable, beta, nightly, 1.65.0]
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
       #  if: matrix.toolchain == 'stable' && matrix.os == 'ubuntu-latest'
 
       # run tests
-      - run: cargo install cargo-hack
+      - name: install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - run: cargo hack test --workspace --each-feature
         if: matrix.toolchain == 'nightly'
       - run: cargo hack test --workspace --each-feature --skip nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.19.0 (2022-07-15)
+# 0.19.0 (2023-06-10)
 
 * Bump MSRV to 1.65.0 ([#766])
 * Added index where entity deletion stopped to the error returned from `WorldExt::delete_entities` ([#766])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 0.19.0 (2022-07-15)
 
+* Bump MSRV to 1.65.0 ([#766])
 * Added index where entity deletion stopped to the error returned from `WorldExt::delete_entities` ([#766])
 * Fix bug where deleting an entity with the wrong generation could clear the components of an existing entity. ([#766])
 * Bump shred to version `0.14.1`, MSRV to 1.60.0 ([shred changelog][shred-changelog], [#756])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # 0.19.0 (2022-07-15)
 
+* Added index where entity deletion stopped to the error returned from `WorldExt::delete_entities` ([#766])
+* Fix bug where deleting an entity with the wrong generation could clear the components of an existing entity. ([#766])
 * Bump shred to version `0.14.1`, MSRV to 1.60.0 ([shred changelog][shred-changelog], [#756])
 
 [#756]: https://github.com/amethyst/specs/pull/756
+[#766]: https://github.com/amethyst/specs/pull/766
 
 # 0.18.0 (2022-07-02)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 authors = ["slide-rs hackers"]
 include = ["src", "README.md", "LICENSE-MIT", "LICENSE-APACHE"]
 edition = "2021"
-rust-version = "1.60.0"
+rust-version = "1.65.0"
 
 # the `storage_cmp` and `storage_sparse` benches are called from `benches_main`
 autobenches = false

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Unlike most other ECS libraries out there, it provides
       other and you can use barriers to force several stages in system execution
 * high performance for real-world applications
 
-Minimum Rust version: 1.40
+Minimum Rust version: 1.65
 
 ## [Link to the book][book]
 

--- a/deny.toml
+++ b/deny.toml
@@ -28,3 +28,7 @@ allow = ["MIT", "Apache-2.0", "Unlicense", "BSD-3-Clause"]
 
 # We want really high confidence when inferring licenses from text
 confidence-threshold = 0.93
+
+exceptions = [
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
+]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,6 +54,35 @@ fn task_panics() {
 }
 
 #[test]
+fn delete_wrong_gen() {
+    let mut world = create_world();
+
+    // create
+    let entity_a = world.create_entity().with(CompInt(7)).build();
+    assert_eq!(
+        world.read_component::<CompInt>().get(entity_a),
+        Some(&CompInt(7))
+    );
+    // delete
+    assert!(world.delete_entity(entity_a).is_ok());
+    assert_eq!(world.read_component::<CompInt>().get(entity_a), None);
+    // create
+    let entity_b = world.create_entity().with(CompInt(6)).build();
+    assert_eq!(
+        world.read_component::<CompInt>().get(entity_b),
+        Some(&CompInt(6))
+    );
+    assert_eq!(world.read_component::<CompInt>().get(entity_a), None);
+    // delete stale
+    assert!(world.delete_entity(entity_a).is_err());
+    assert_eq!(
+        world.read_component::<CompInt>().get(entity_b),
+        Some(&CompInt(6))
+    );
+    assert_eq!(world.read_component::<CompInt>().get(entity_a), None);
+}
+
+#[test]
 fn dynamic_create() {
     struct Sys;
 


### PR DESCRIPTION
<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [x] I've added tests for all code changes and additions (where applicable)
* ~~[ ] I've added a demonstration of the new feature to one or more examples~~
* ~~[ ] I've updated the book to reflect my changes~~
* ~~[ ] Usage of new public items is shown in the API docs~~

## API changes

<!-- Please make it clear if your change is breaking. -->

`WorldExt::delete_entities` method now includes the index of the entity with the wrong generation to indicate to the user where it stopped (since entities after that are not deleted).
