### PR TITLE
Update shred to 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ahash = "0.7.6"
 crossbeam-queue = "0.3"
 hibitset = { version = "0.6.4", default-features = false }
 log = "0.4.8"
-shred = { version = "0.15.0", default-features = false }
+shred = { version = "0.16.0", default-features = false }
 shrev = "1.1.1"
 tuple_utils = "0.4.0"
 nougat = "0.2.3"
@@ -37,8 +37,8 @@ uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }
 [features]
 default = ["parallel"]
 parallel = ["dep:rayon", "shred/parallel", "hibitset/parallel"]
-uuid_entity = ["uuid", "serde"]
-stdweb = ["uuid/js"]
+uuid_entity = ["dep:uuid", "serde"]
+stdweb = ["dep:uuid", "uuid?/js"]
 storage-event-control = []
 derive = ["shred-derive", "specs-derive"]
 nightly = ["shred/nightly"]
@@ -54,7 +54,7 @@ criterion = "0.3.1"
 ron = "0.7.1"
 rand = "0.8"
 serde_json = "1.0.48"
-shred = { version = "0.15.0", default-features = false, features = ["shred-derive"] }
+shred = { version = "0.16.0", default-features = false, features = ["shred-derive"] }
 specs-derive = { path = "specs-derive", version = "0.4.1" }
 
 [[example]]

--- a/docs/tutorials/src/06_system_data.md
+++ b/docs/tutorials/src/06_system_data.md
@@ -119,6 +119,8 @@ That's why you can also create your own `SystemData` bundle using a struct:
 extern crate specs;
 
 use specs::prelude::*;
+// `shred` needs to be in scope for the `SystemData` derive. 
+use specs::shred;
 
 #[derive(SystemData)]
 pub struct MySystemData<'a> {

--- a/examples/full.rs
+++ b/examples/full.rs
@@ -1,4 +1,4 @@
-use specs::{prelude::*, storage::HashMapStorage};
+use specs::{prelude::*, shred, storage::HashMapStorage};
 
 // -- Components --
 // A component exists for 0..n

--- a/miri.sh
+++ b/miri.sh
@@ -15,7 +15,10 @@ echo "using filter: \"$filter\""
 # Miri currently reports leaks in some tests so we disable that check
 # here (might be due to ptr-int-ptr in crossbeam-epoch so might be
 # resolved in future versions of that crate).
-MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+#
+# crossbeam-epoch doesn't pass with stacked borrows so we need to use tree-borrows
+# https://github.com/crossbeam-rs/crossbeam/issues/545
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tree-borrows" \
     cargo +nightly miri nextest run \
     -E "$filter" \
     --test-threads="$test_threads" \
@@ -23,7 +26,7 @@ MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
     #--nocapture
 
 # Run tests only available when parallel feature is disabled.
-MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks" \
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-tree-borrows" \
     cargo +nightly miri nextest run \
     --no-default-features \
     -E "binary(no_parallel)" \

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,8 +209,8 @@ pub mod world;
 pub use hibitset::BitSet;
 pub use shred::{
     Accessor, AccessorCow, BatchAccessor, BatchController, BatchUncheckedWorld, Dispatcher,
-    DispatcherBuilder, Read, ReadExpect, RunNow, RunningTime, StaticAccessor, System, SystemData,
-    World, Write, WriteExpect,
+    DispatcherBuilder, Read, ReadExpect, RunNow, RunningTime, SendDispatcher, StaticAccessor,
+    System, SystemData, World, Write, WriteExpect,
 };
 pub use shrev::ReaderId;
 


### PR DESCRIPTION
 Also hide optional uuid dep from features since it is enabled indirectly via `uuid_entity` feature (and not intended to be enabled directly)

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [x] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

This is a breaking change.

The `SystemData` derive now requires `shred` to be in scope rather than all the individual types that the derive needs.

<!-- Please make it clear if your change is breaking. -->
