### PR TITLE
Implement GenericReadStorage for mutable reference

### DIFF
--- a/src/storage/generic.rs
+++ b/src/storage/generic.rs
@@ -78,6 +78,22 @@ where
     }
 }
 
+
+impl<'a: 'b, 'b, T> GenericReadStorage for &'b mut WriteStorage<'a, T>
+where
+    T: Component,
+{
+    type Component = T;
+
+    fn get(&self, entity: Entity) -> Option<&Self::Component> {
+        WriteStorage::get(*self, entity)
+    }
+
+    fn _private() -> Seal {
+        Seal
+    }
+}
+
 /// Provides generic write access to `WriteStorage`, both as a value and a
 /// mutable reference.
 pub trait GenericWriteStorage {


### PR DESCRIPTION
Without this it's not possible to pass `&mut WriteStorage<_>` as a `GenericReadStorage`.

<!-- Before creating a PR, please make sure you read the contribution guidelines. -->
<!-- Feel free to delete points if they don't make sense for this PR. -->
<!-- You can tick boxes by putting an "x" inside the braces, or by clicking them once the comment is published. -->

<!-- Please use "Fixes #nr" and "Related #nr", respectively. -->

## Checklist

* [ ] I've added tests for all code changes and additions (where applicable)
* [ ] I've added a demonstration of the new feature to one or more examples
* [ ] I've updated the book to reflect my changes
* [ ] Usage of new public items is shown in the API docs

## API changes

<!-- Please make it clear if your change is breaking. -->
